### PR TITLE
[codex] Fix launch refresh and Claude account display

### DIFF
--- a/Core/AppState.swift
+++ b/Core/AppState.swift
@@ -88,6 +88,8 @@ final class AppState {
             quotaInterval: settings.quotaInterval.seconds,
             usageInterval: settings.usageInterval.seconds
         )
+        // 首次启动不等待完整刷新间隔,否则 10m 间隔下会长时间显示空额度。
+        Task { await refreshQuotas(reason: .periodic) }
         // 启动后台触发一次 JSONL 扫描，让今日 cost 立刻更新（不阻塞 bootstrap）
         Task { await usageService.scanNow() }
         // 启动后异步拉一次服务状态;后续由 Scheduler 5 分钟刷新一次

--- a/Core/Credentials/ClaudeAuth.swift
+++ b/Core/Credentials/ClaudeAuth.swift
@@ -10,17 +10,40 @@ enum ClaudeAuth {
     }
 
     /// Claude 的 OAuth 凭据本身不含邮箱，CLI 登录时会把账号信息额外写到
-    /// `~/.claude.json` 顶层的 `oauthAccount` 字段。这里只读 emailAddress 作为兜底。
+    /// `~/.claude.json` 顶层的 `oauthAccount` 字段。订阅组织名有时才是当前
+    /// Claude Code 额度归属账号,因此优先从 organizationName 中提取邮箱。
     nonisolated private static func loadEmailFromConfig() -> String? {
         let url = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".claude.json")
         guard let data = try? Data(contentsOf: url),
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let oauth = root["oauthAccount"] as? [String: Any],
-              let email = oauth["emailAddress"] as? String,
-              !email.isEmpty
+              let oauth = root["oauthAccount"] as? [String: Any]
         else { return nil }
-        return email
+        if let organizationName = oauth["organizationName"] as? String,
+           let email = extractEmail(from: organizationName) {
+            return email
+        }
+        return nonEmpty(oauth["emailAddress"] as? String)
+            ?? nonEmpty(oauth["email"] as? String)
+    }
+
+    nonisolated private static func extractEmail(from text: String) -> String? {
+        let pattern = #"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return nil
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, range: range),
+              let emailRange = Range(match.range, in: text)
+        else { return nil }
+        return String(text[emailRange])
+    }
+
+    nonisolated private static func nonEmpty(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty
+        else { return nil }
+        return value
     }
 
     nonisolated private static func loadFromFile() throws -> ClaudeAccount? {

--- a/Info.plist
+++ b/Info.plist
@@ -25,7 +25,7 @@
     <key>NSHumanReadableCopyright</key>
     <string></string>
     <key>NSSupportsAutomaticTermination</key>
-    <true/>
+    <false/>
     <key>NSSupportsSuddenTermination</key>
     <true/>
 </dict>

--- a/Main/DesignSystem.swift
+++ b/Main/DesignSystem.swift
@@ -25,7 +25,7 @@ func statusColor(remainingPercent: Double?, tint: Color) -> Color {
 // normal 档统一用石墨灰(中性灰),不随服务识别色变化。
 private let quotaNormalColor = quotaAdaptiveColor(
     light: (red: 108, green: 108, blue: 112), // #6C6C70
-    dark: (red: 152, green: 152, blue: 157)   // #98989D
+    dark: (red: 216, green: 216, blue: 210)   // #D8D8D2
 )
 
 private let quotaWarningColor = quotaAdaptiveColor(
@@ -57,6 +57,62 @@ private func quotaAdaptiveColor(
             alpha: 1
         )
     })
+}
+
+// MARK: - Popover high-contrast palette
+//
+// Popover 覆在半透明深灰 material 上,系统 secondary / tertiary 容易发灰。
+// 这里集中定义一套只给 Popover 使用的高对比语义色。
+
+enum CCPopoverPalette {
+    static let panelFill = dynamicColor(
+        light: (red: 244, green: 241, blue: 234, alpha: 0.88), // #F4F1EA
+        dark: (red: 58, green: 58, blue: 56, alpha: 0.92)      // #3A3A38
+    )
+    static let primaryText = dynamicColor(
+        light: (red: 31, green: 35, blue: 40, alpha: 1.0),     // #1F2328
+        dark: (red: 245, green: 245, blue: 242, alpha: 1.0)    // #F5F5F2
+    )
+    static let secondaryText = dynamicColor(
+        light: (red: 88, green: 96, blue: 105, alpha: 1.0),    // #586069
+        dark: (red: 201, green: 201, blue: 196, alpha: 1.0)    // #C9C9C4
+    )
+    static let weakText = dynamicColor(
+        light: (red: 110, green: 119, blue: 129, alpha: 1.0),  // #6E7781
+        dark: (red: 168, green: 168, blue: 162, alpha: 1.0)    // #A8A8A2
+    )
+    static let iconText = dynamicColor(
+        light: (red: 75, green: 85, blue: 99, alpha: 1.0),     // #4B5563
+        dark: (red: 216, green: 216, blue: 210, alpha: 1.0)    // #D8D8D2
+    )
+    static let separator = dynamicColor(
+        light: (red: 31, green: 35, blue: 40, alpha: 0.12),
+        dark: (red: 245, green: 245, blue: 242, alpha: 0.12)
+    )
+    static let progressTrack = dynamicColor(
+        light: (red: 110, green: 119, blue: 129, alpha: 0.16),
+        dark: (red: 138, green: 138, blue: 132, alpha: 0.45)   // #8A8A84
+    )
+    static let buttonHoverFill = dynamicColor(
+        light: (red: 31, green: 35, blue: 40, alpha: 0.08),
+        dark: (red: 245, green: 245, blue: 242, alpha: 0.12)
+    )
+
+    private static func dynamicColor(
+        light: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat),
+        dark: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
+    ) -> Color {
+        Color(nsColor: NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            let rgba = isDark ? dark : light
+            return NSColor(
+                calibratedRed: rgba.red / 255,
+                green: rgba.green / 255,
+                blue: rgba.blue / 255,
+                alpha: rgba.alpha
+            )
+        })
+    }
 }
 
 // MARK: - Reset time (hover 切换格式)
@@ -281,12 +337,13 @@ struct ProgressBar: View {
     let value: Double
     let tint: Color
     var height: CGFloat = 5
+    var track: Color = Color.secondary.opacity(0.18)
 
     var body: some View {
         GeometryReader { proxy in
             ZStack(alignment: .leading) {
                 Capsule()
-                    .fill(Color.secondary.opacity(0.18))
+                    .fill(track)
 
                 Capsule()
                     .fill(tint)
@@ -444,7 +501,7 @@ struct PopoverIconButtonStyle: ButtonStyle {
             .frame(width: 26, height: 22)
             .background(
                 RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .fill(hovering && isEnabled ? Color.primary.opacity(0.08) : .clear)
+                    .fill(hovering && isEnabled ? CCPopoverPalette.buttonHoverFill : .clear)
             )
             .opacity(configuration.isPressed ? 0.5 : 1)
             .contentShape(Rectangle())

--- a/MenuBar/OtherCodexAccountsSection.swift
+++ b/MenuBar/OtherCodexAccountsSection.swift
@@ -21,6 +21,7 @@ struct OtherCodexAccountsSection: View {
                 ForEach(Array(accounts.enumerated()), id: \.element.id) { idx, account in
                     if idx > 0 {
                         Divider()
+                            .overlay(CCPopoverPalette.separator)
                             .padding(.leading, 16)
                             .padding(.trailing, 16)
                     }
@@ -35,14 +36,14 @@ struct OtherCodexAccountsSection: View {
             Text(tr("OTHER CODEX ACCOUNTS", "其他账号"))
                 .font(.system(size: 9.5, weight: .semibold))
                 .kerning(0.3)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(CCPopoverPalette.weakText)
 
             Spacer()
 
             Text("\(count)")
                 .font(.system(size: 9.5, weight: .semibold))
                 .monospacedDigit()
-                .foregroundStyle(.quaternary)
+                .foregroundStyle(CCPopoverPalette.weakText)
         }
         .padding(.horizontal, 16)
         .padding(.top, 10)
@@ -70,12 +71,13 @@ private struct ImportedCodexRow: View {
                 if !displayName.isEmpty {
                     Text(displayName)
                         .font(.system(size: 12))
+                        .foregroundStyle(CCPopoverPalette.primaryText)
                         .lineLimit(1)
                 }
                 if !displaySubtitle.isEmpty {
                     Text(displaySubtitle)
                         .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(CCPopoverPalette.secondaryText)
                         .lineLimit(1)
                 }
             }
@@ -104,13 +106,14 @@ private struct ImportedCodexRow: View {
             Text(label)
                 .font(.system(size: 8.5, weight: .semibold))
                 .kerning(0.5)
-                .foregroundStyle(.quaternary)
+                .foregroundStyle(CCPopoverPalette.weakText)
                 .frame(width: 18, alignment: .leading)
 
             ProgressBar(
                 value: (window?.remainingPercent ?? 0) / 100,
                 tint: rowColor(window: window),
-                height: 2
+                height: 2,
+                track: CCPopoverPalette.progressTrack
             )
 
             Text(percentText(window: window))
@@ -121,7 +124,7 @@ private struct ImportedCodexRow: View {
 
             ResetTimeText(resetsAt: window?.resetsAt)
                 .font(.system(size: 10))
-                .foregroundStyle(.quaternary)
+                .foregroundStyle(CCPopoverPalette.weakText)
                 .frame(width: 70, alignment: .trailing)
         }
     }
@@ -135,17 +138,17 @@ private struct ImportedCodexRow: View {
                         .frame(width: 12, height: 12)
                     Text(tr("Loading…", "加载中…"))
                         .font(.system(size: 10.5))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(CCPopoverPalette.secondaryText)
                 }
             } else if let err = error {
                 Text(shortError(err))
                     .font(.system(size: 10.5))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(CCPopoverPalette.secondaryText)
                     .lineLimit(1)
             } else {
                 Text("—")
                     .font(.system(size: 10.5))
-                    .foregroundStyle(.quaternary)
+                    .foregroundStyle(CCPopoverPalette.weakText)
             }
         }
     }
@@ -174,7 +177,7 @@ private struct ImportedCodexRow: View {
     }
 
     private func rowColor(window: QuotaWindow?) -> Color {
-        guard let window else { return .secondary }
+        guard let window else { return CCPopoverPalette.secondaryText }
         return statusColor(remainingPercent: window.remainingPercent, tint: .codexAccent)
     }
 

--- a/MenuBar/PopoverRootView.swift
+++ b/MenuBar/PopoverRootView.swift
@@ -18,10 +18,12 @@ struct PopoverRootView: View {
             header
 
             Divider()
+                .overlay(CCPopoverPalette.separator)
 
             content
         }
         .frame(width: 340)
+        .background(CCPopoverPalette.panelFill)
     }
 
     // MARK: Header
@@ -31,13 +33,14 @@ struct PopoverRootView: View {
             VStack(alignment: .leading, spacing: 1) {
                 Text(tr("Usage", "用量"))
                     .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(CCPopoverPalette.primaryText)
 
                 // 用 TimelineView 每秒重新渲染一次,让 "Xs 前已刷新" 实时滚动。
                 // Popover 不可见时 TimelineView 不会被调度,几乎零 CPU 成本。
                 TimelineView(.periodic(from: .now, by: 1)) { context in
                     Text(headerSubtitle(now: context.date))
                         .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(CCPopoverPalette.secondaryText)
                         .monospacedDigit()
                         .lineLimit(1)
                 }
@@ -56,7 +59,7 @@ struct PopoverRootView: View {
             Button(action: refresh) {
                 Image(systemName: "arrow.clockwise")
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(CCPopoverPalette.iconText)
                     .rotationEffect(.degrees(refreshRotation))
                     .animation(.easeInOut(duration: 0.7), value: refreshRotation)
             }
@@ -68,7 +71,7 @@ struct PopoverRootView: View {
             Button { activateAndOpenMain() } label: {
                 Image(systemName: "chart.bar.xaxis")
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(CCPopoverPalette.iconText)
             }
             .buttonStyle(PopoverIconButtonStyle())
             .help(tr("Open Statistics", "查看统计"))
@@ -76,7 +79,7 @@ struct PopoverRootView: View {
             Button { activateAndOpenMain() } label: {
                 Image(systemName: "gearshape")
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(CCPopoverPalette.iconText)
             }
             .buttonStyle(PopoverIconButtonStyle())
             .help(tr("Settings", "设置"))
@@ -84,7 +87,7 @@ struct PopoverRootView: View {
             Button { NSApp.terminate(nil) } label: {
                 Image(systemName: "power")
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(CCPopoverPalette.iconText)
             }
             .buttonStyle(PopoverIconButtonStyle())
             .help(tr("Quit", "退出"))
@@ -122,10 +125,10 @@ struct PopoverRootView: View {
             VStack(spacing: 6) {
                 Text(tr("No services enabled", "未启用任何服务"))
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(CCPopoverPalette.secondaryText)
                 Text(tr("Enable a service in Settings → Accounts", "到「设置 → 账号」开启"))
                     .font(.system(size: 11))
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(CCPopoverPalette.weakText)
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 24)
@@ -149,12 +152,16 @@ struct PopoverRootView: View {
                 // 其他 Codex 账号分区（visible 为 0 时自动隐藏）
                 let hasImported = appState.importedCodexAccounts.contains(where: \.visibleInPopover)
                 if hasImported {
-                    Divider().padding(.horizontal, 16)
+                    Divider()
+                        .overlay(CCPopoverPalette.separator)
+                        .padding(.horizontal, 16)
                     OtherCodexAccountsSection()
                 }
 
                 if showClaude && (showCodex || hasImported) {
-                    Divider().padding(.horizontal, 16)
+                    Divider()
+                        .overlay(CCPopoverPalette.separator)
+                        .padding(.horizontal, 16)
                 }
                 if showClaude {
                     ServiceBlockView(
@@ -298,7 +305,7 @@ private struct ServiceBlockView: View {
             if let message = shortError(error) {
                 Text(message)
                     .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(CCPopoverPalette.secondaryText)
                     .lineLimit(2)
             }
         }
@@ -315,11 +322,11 @@ private struct ServiceBlockView: View {
                 Text(title)
                     .font(.system(size: 13, weight: .semibold))
                     .kerning(-0.1)
-                    .foregroundColor(.primary)
+                    .foregroundColor(CCPopoverPalette.primaryText)
                 + Text("   ")
                 + Text(subtitle)
                     .font(.system(size: 11))
-                    .foregroundColor(.secondary.opacity(0.75))
+                    .foregroundColor(CCPopoverPalette.secondaryText.opacity(0.9))
             )
             .lineLimit(1)
             .truncationMode(.tail)
@@ -363,18 +370,23 @@ private struct ServiceBlockView: View {
                 Text("5-HOUR · 五小时")
                     .font(.system(size: 9, weight: .semibold))
                     .kerning(0.5)
-                    .foregroundStyle(.quaternary)
+                    .foregroundStyle(CCPopoverPalette.weakText)
             }
 
             // 右:5h 进度条 + 两行(数值 / label)
             VStack(alignment: .leading, spacing: 8) {
-                ProgressBar(value: fiveHourRemaining / 100, tint: fiveHourColor, height: 7)
+                ProgressBar(
+                    value: fiveHourRemaining / 100,
+                    tint: fiveHourColor,
+                    height: 7,
+                    track: CCPopoverPalette.progressTrack
+                )
 
                 VStack(spacing: 1) {
                     HStack(spacing: 0) {
                         ResetTimeText(resetsAt: snapshot?.fiveHour?.resetsAt)
                             .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(.primary)
+                            .foregroundStyle(CCPopoverPalette.primaryText)
                             .lineLimit(1)
 
                         Spacer(minLength: 8)
@@ -388,13 +400,13 @@ private struct ServiceBlockView: View {
                     HStack(spacing: 0) {
                         BilingualInline(english: "reset", chinese: "重置")
                             .font(.system(size: 9.5))
-                            .foregroundStyle(.quaternary)
+                            .foregroundStyle(CCPopoverPalette.weakText)
 
                         Spacer(minLength: 0)
 
                         BilingualInline(english: "cost", chinese: "花费")
                             .font(.system(size: 9.5))
-                            .foregroundStyle(.quaternary)
+                            .foregroundStyle(CCPopoverPalette.weakText)
                     }
                 }
             }
@@ -407,10 +419,15 @@ private struct ServiceBlockView: View {
             Text("WK")
                 .font(.system(size: 9, weight: .semibold))
                 .kerning(0.6)
-                .foregroundStyle(.quaternary)
+                .foregroundStyle(CCPopoverPalette.weakText)
                 .frame(width: 36, alignment: .leading)
 
-            ProgressBar(value: weeklyRemaining / 100, tint: weeklyColor, height: 2.5)
+            ProgressBar(
+                value: weeklyRemaining / 100,
+                tint: weeklyColor,
+                height: 2.5,
+                track: CCPopoverPalette.progressTrack
+            )
 
             Text(weeklyPercentText)
                 .font(.system(size: 10.5, weight: .medium))
@@ -419,7 +436,7 @@ private struct ServiceBlockView: View {
 
             ResetTimeText(resetsAt: snapshot?.weekly?.resetsAt)
                 .font(.system(size: 10.5))
-                .foregroundStyle(.quaternary)
+                .foregroundStyle(CCPopoverPalette.weakText)
         }
     }
 
@@ -427,11 +444,11 @@ private struct ServiceBlockView: View {
         HStack(spacing: 4) {
             BilingualInline(english: english, chinese: chinese)
                 .font(.system(size: 10))
-                .foregroundStyle(.quaternary)
+                .foregroundStyle(CCPopoverPalette.weakText)
             Text(value)
                 .font(.system(size: 11, weight: .medium))
                 .monospacedDigit()
-                .foregroundStyle(.primary)
+                .foregroundStyle(CCPopoverPalette.primaryText)
         }
     }
 
@@ -446,12 +463,12 @@ private struct ServiceBlockView: View {
     }
 
     private var fiveHourColor: Color {
-        guard snapshot?.fiveHour != nil else { return .secondary }
+        guard snapshot?.fiveHour != nil else { return CCPopoverPalette.secondaryText }
         return statusColor(remainingPercent: fiveHourRemaining, tint: tint)
     }
 
     private var weeklyColor: Color {
-        guard snapshot?.weekly != nil else { return .secondary }
+        guard snapshot?.weekly != nil else { return CCPopoverPalette.secondaryText }
         return statusColor(remainingPercent: weeklyRemaining, tint: tint)
     }
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cc-bar 是 vibe coding 出来满足个人需求的小工具,并非商业化产�
    ./scripts/build.sh
    ```
 
-   脚本会以 `CODE_SIGNING_ALLOWED=NO` 做 Release 构建(工具链自动 ad-hoc 签名),
+   脚本会以 `CODE_SIGNING_ALLOWED=NO` 做 Release 构建,随后显式 ad-hoc 重签整个 `.app`,
    清理扩展属性并打包,产物输出到 `dist/CCBar.app.zip`。
 
 3. 把 `dist/CCBar.app.zip` 上传到 GitHub Release 即可。用户首次安装按上方「安装」一节手动放行一次。

--- a/docs/产品需求.md
+++ b/docs/产品需求.md
@@ -80,7 +80,7 @@
   - 手动「立即刷新」可绕过 60s 节流但仍遵守 429 退避。
 - Claude API 失败且**完全没有可展示缓存**时，手动刷新会触发一次 Claude CLI 兜底（启动 `claude` 进程，向其 stdin 写入 `/usage`，解析输出），CLI 兜底也有独立 10 分钟冷却。
 - Token 续期：Codex / Claude 双方均在 access_token 距离过期 5 分钟内时用 refresh_token 自动续期，并把新 token 写回原存储位置（文件或 Keychain）。
-- 启动行为：先读本地额度缓存让 UI 立刻有数；首次刷新由调度器节奏触发；网络失败保留已有快照，仅以小字提示。
+- 启动行为：先读本地额度缓存让 UI 立刻有数；随后异步触发一次额度刷新，不等待完整调度间隔；网络失败保留已有快照，仅以小字提示。
 
 ---
 
@@ -178,4 +178,4 @@
 2. **Keychain 弹窗**：首次读 `Claude Code-credentials` 系统会弹一次授权窗，引导文案已加。
 3. **价格表漂移**：当前对齐 cc-switch / CodexBar 2026 上半年价位；模型迭代后需要同步。
 4. **JSONL 量级**：长期使用后 `~/.claude/projects` 可达数百 MB；增量 watermark + seen ID 上限保证启动 / 扫描时间可控，但 seen 集合上限 20000 时若历史窗口超过该长度会有边缘重复风险。
-5. **签名与公证**：发布前需 Apple Developer 证书；当前开发期未签名，README 标注「右键打开」。
+5. **签名与公证**：发布前需 Apple Developer 证书；当前开发期使用 ad-hoc 签名但未公证，README 标注首次启动需手动放行。

--- a/docs/技术实现.md
+++ b/docs/技术实现.md
@@ -28,7 +28,7 @@ cc-bar/
 ├── ccbar.xcodeproj/
 ├── CCBarApp.swift                # @main，组装 MenuBarExtra + Main window + Onboarding window
 ├── AppDelegate.swift             # NSApp.setActivationPolicy(.accessory)
-├── Info.plist                    # LSUIElement = true
+├── Info.plist                    # LSUIElement = true，关闭自动终止以保持菜单栏常驻
 ├── CCBar.entitlements
 ├── Core/
 │   ├── AppState.swift            # @Observable 全局状态 + 刷新协调
@@ -117,7 +117,7 @@ cc-bar/
 
 关键方法：
 
-- `bootstrap()`：只执行一次；按顺序加载 quota 缓存 → `UsageService.bootstrap` → 读 Codex 凭据 → 必要时弹 Keychain 引导 → 读 Claude 凭据 → 决定是否展示引导 → 启动 Scheduler → 触发首次 JSONL 扫描（异步不阻塞）。
+- `bootstrap()`：只执行一次；按顺序加载 quota 缓存 → `UsageService.bootstrap` → 读 Codex 凭据 → 必要时弹 Keychain 引导 → 读 Claude 凭据 → 决定是否展示引导 → 启动 Scheduler → 触发首次额度刷新、首次 JSONL 扫描与服务状态拉取（均异步不阻塞）。
 - `refreshNow()`：用户手动刷新；触发一次额度刷新、JSONL 扫描和服务状态拉取。
 - `refreshQuotas(reason:)`：每次刷新(手动 / Scheduler 定时)都先重读 Codex / Claude 凭据，再分别调度额度刷新并写日志摘要。`loadCodex` / `loadClaude` 内部比较 `accountId` / `email`，发现身份变化(例如 cc-switch 外部切换了账号)时清掉旧的额度快照与磁盘缓存，避免出现"新账号 + 旧额度"的错配。
 - `applySettingsChange()`：设置项变化后立即把新间隔灌进 Scheduler。
@@ -136,7 +136,7 @@ cc-bar/
 
 ### 5.2 Claude
 
-`ClaudeAuth.load()` 优先读 `~/.claude/.credentials.json`；不存在再调 `security find-generic-password -s "Claude Code-credentials" -w` 读 Keychain。邮箱兜底来自 `~/.claude.json` 顶层 `oauthAccount.emailAddress`。
+`ClaudeAuth.load()` 优先读 `~/.claude/.credentials.json`；不存在再调 `security find-generic-password -s "Claude Code-credentials" -w` 读 Keychain。邮箱兜底来自 `~/.claude.json` 顶层 `oauthAccount`：若 `organizationName` 中包含邮箱则优先使用该组织邮箱，否则使用 `emailAddress`。
 
 `ClaudeTokenRefresher.ensureFreshAccessToken`：
 
@@ -177,8 +177,8 @@ Claude 的 OAuth `refresh_token` 是 *一次性* 的：每次刷新服务端会�
 
 ### 6.2 调用策略
 
-- 启动只读 `quota-cache.json` 灌进 AppState，**不**立刻打网络。
-- 周期循环按设置间隔触发（默认 5 分钟，可关闭）；任意一家上次成功 < 60s 时跳过。
+- 启动先读 `quota-cache.json` 灌进 AppState，让 UI 立刻有上次快照；随后异步触发一次额度刷新，不等待完整周期间隔。
+- 周期循环按设置间隔触发（默认 2 分钟，可关闭）；任意一家上次成功 < 60s 时跳过。
 - 收到 429 后该服务进入 10 分钟退避，期间所有触发短路。
 - 手动刷新绕过 60s 节流，但仍遵守 429 退避。
 - 401 / 403 不会自动停止循环（保持简单），但错误会显示在 Popover。
@@ -275,7 +275,7 @@ OpenAI / Anthropic 各自的 Statuspage.io 公开接口,无需鉴权,用于在 P
 
 `@MainActor`，持有 AppState 弱引用，三条独立 `Task` 循环：
 
-- **额度循环**：`quotaInterval` 秒触发一次 `appState.refreshQuotas(reason: .periodic)`。设置项可选 `1 / 2 / 3 / 5 / 10` 分钟，默认 2 分钟；`Scheduler` 仍保留对 `nil` / 0 的兜底，不启动循环。
+- **额度循环**：启动后由 `AppState.bootstrap()` 立即异步触发一次额度刷新；之后 `quotaInterval` 秒触发一次 `appState.refreshQuotas(reason: .periodic)`。设置项可选 `1 / 2 / 3 / 5 / 10` 分钟，默认 2 分钟；`Scheduler` 仍保留对 `nil` / 0 的兜底，不启动循环。
 - **用量循环**：`usageInterval` 秒触发一次 `appState.usageService.scanNow()`。
 - **服务状态循环**：固定 5 分钟触发一次 `appState.refreshServiceStatus()`，与额度/用量解耦（statuspage 变化慢，无需跟随用户的额度刷新间隔）。
 

--- a/docs/界面布局.md
+++ b/docs/界面布局.md
@@ -21,7 +21,7 @@
 | 宽 | 340pt(固定) |
 | 高 | auto;双服务 ~320pt,单服务 ~180pt,零服务 ~110pt(提示空状态) |
 | 圆角 | 18pt(`NSPopover` 系统提供,不自绘) |
-| 材质 | `.popover`(系统) |
+| 材质 | `.popover`(系统) + `CCPopoverPalette.panelFill` 高对比半透明底色 |
 | 锚点 | 菜单栏图标下方,7pt arrow notch 朝上 |
 | 出现动画 | 系统默认(`MenuBarExtra(.window)` 提供) |
 
@@ -31,7 +31,7 @@
 ┌───────────────────────────────────────────────────────────┐
 │ Header                                       14/12/12pt  │
 │   "Usage"  13pt 600                                       │
-│   "用量 · refreshed 32s ago"  11pt secondary              │
+│   "用量 · refreshed 32s ago"  11pt secondaryText          │
 │                          ● [📊] [↻] [⚙] [⏻]               │
 ├───────────────────────────────────────────────────────────┤  ← 0.5pt separator full
 │ Codex block                                  14/16pt     │
@@ -61,18 +61,18 @@
 - **容器**:HStack(spacing 4),padding `14pt 上 / 12pt 左右 / 12pt 下`(到 separator)。
 - **左侧**(VStack,line-height 1.1):
   - `Usage` — 13pt .semibold
-  - `用量 · refreshed 32s ago` — 11pt secondary
+  - `用量 · refreshed 32s ago` — 11pt `CCPopoverPalette.secondaryText`
     - `refreshed {n}s ago` / `{n}m ago` / `{n}h ago`,取 Codex 与 Claude 中**最近**一次成功时间;无成功时显示 `用量 · 等待数据`。
 - **右侧**(HStack,spacing 4):
   1. **status dot** — 7pt 圆点(live/stale/offline),颜色按 设计风格 §4.3,hover tooltip `Live · 在线` 等。
-  2. **Open Statistics** — `chart.bar.xaxis` 13pt,按钮 `26pt × 22pt` 圆角 5pt,hover 浅灰背景(`Color.primary.opacity(0.08)`)+ 手型光标。点击 `openWindow(id: "main")`,Popover 关闭。
+  2. **Open Statistics** — `chart.bar.xaxis` 13pt,图标色 `CCPopoverPalette.iconText`,按钮 `26pt × 22pt` 圆角 5pt,hover `CCPopoverPalette.buttonHoverFill` + 手型光标。点击 `openWindow(id: "main")`,Popover 关闭。
   3. **Refresh** — `arrow.clockwise` 13pt,同尺寸按钮。点击触发 `appState.refreshNow()`,图标旋转 360° / 700ms ease-in-out,刷新中按钮 disabled。
   4. **Settings** — `gearshape` 13pt,同尺寸按钮。点击打开主窗口(当前与 Statistics 共用入口,落到 `appState.mainTab` 当前所记的 tab;⌘, 命令会显式切到设置 tab)。
   5. **Quit** — `power` 13pt,同尺寸。点击 `NSApp.terminate(nil)`,hover tooltip `Quit · 退出`。
 
 > 设计依据:用户反馈一级操作(设置 / 刷新 / 统计 / 退出)藏在 kebab + footer 里不直观,统一拉到顶部图标行,降低点击层级。Quit 早期收在 `ellipsis` 菜单需要点两次,后续也拉平为一级图标。
 
-- **separator**:0.5pt 全宽,`.separatorColor`。
+- **separator**:0.5pt 全宽,`CCPopoverPalette.separator`。
 
 ### 1.4 服务 block(Codex / Claude 共用结构)
 
@@ -83,10 +83,10 @@
 | 元素 | 规格 |
 |---|---|
 | 服务 tile | 22pt × 22pt squircle(6pt 圆角),服务识别色填充,白色 logo 14pt 居中。详见 设计风格 §11.2。 |
-| 服务名 + plan(VStack,line-height 1.08) | `Codex` 13pt .semibold kerning -0.1<br>`OpenAI · Plus` 10.5pt secondary(plan 取自 `appState.codexAccount?.planType`,缺失时只显示 `OpenAI`) |
+| 服务名 + plan(VStack,line-height 1.08) | `Codex` 13pt .semibold kerning -0.1,`CCPopoverPalette.primaryText`<br>`OpenAI · Plus` 10.5pt `CCPopoverPalette.secondaryText`(plan 取自 `appState.codexAccount?.planType`,缺失时只显示 `OpenAI`) |
 | Spacer | — |
 | 服务状态圆点 | 6pt 圆,贴 Spacer 后,行尾。颜色按 statuspage indicator(none 绿 / minor 黄 / major 橙 / critical 红 / maintenance 蓝),`unknown` 或未拉到时不显示。受设置项 `showServiceStatus` 控制,tooltip 显示 statuspage description + 相对更新时间。 |
-| Reset hint | `resets in 2h 18m` 11pt tabular secondary。取自 5h window 的 `resetsAt`。<br>无数据时显示 `reset unknown`。 |
+| Reset hint | `resets in 2h 18m` 11pt tabular `CCPopoverPalette.primaryText`。取自 5h window 的 `resetsAt`。<br>无数据时显示 `reset unknown`。 |
 
 #### 1.4.2 Body row(HStack,gap 14pt,marginTop 12pt)
 
@@ -95,7 +95,7 @@
 - 进度 = `fiveHour.remainingPercent / 100`,起点 12 点钟,顺时针(剩余越多环越满)。
 - 中央 VStack(spacing 1,line-height 1):
   - 百分比 14pt .semibold tabular(状态色)
-  - `5H` 8pt tertiary letterSpacing 0.2
+  - `5H` 8pt `CCPopoverPalette.weakText` letterSpacing 0.2
 - 状态色规则按 设计风格 §4.3。
 
 **右栏:weekly + stats**(VStack,flex 1)
@@ -103,7 +103,7 @@
 1. **Weekly 标题行**(HStack space-between,marginBottom 4pt):
    - 左:`Weekly · 周额度` 10.5pt secondary
    - 右:`31%` 10.5pt tabular(状态色,见 设计风格 §4.3)
-2. **Weekly 条**:高 5pt,圆角 2.5pt,状态色填充 + `.quaternarySystemFill` 轨道。进度 = `weekly.remainingPercent / 100`。
+2. **Weekly 条**:高 5pt,圆角 2.5pt,状态色填充 + `CCPopoverPalette.progressTrack` 轨道。进度 = `weekly.remainingPercent / 100`。
 3. **Stats 双列**(HStack,gap 14pt,marginTop 9pt):
    - 左:`184k / 440k` 11pt tabular .medium primary(主)+ `tokens used` 9.5pt tertiary(副,在主下方,无 ·)
    - 右:`$12.40` 11pt tabular .medium primary + `this week` 9.5pt tertiary

--- a/docs/设计风格.md
+++ b/docs/设计风格.md
@@ -98,6 +98,8 @@ AppKit 侧:`NSVisualEffectView`,`blendingMode = .behindWindow`。
 | 浅色填充 | `.quaternarySystemFill` / `.secondarySystemFill` |
 | Accent | `systemBlue`(系统自动) |
 
+> Popover 覆在半透明深色 material 上时,系统 `.secondary` / `.tertiary` 对比度偏低。Popover 内文字、图标、分隔线和进度条轨道使用 `CCPopoverPalette` 的高对比语义色,保持原生灰阶观感但提高可读性。
+
 ### 4.2 产品识别色(唯一两个写死的颜色)
 
 | 服务 | 浅色 | 深色 |
@@ -117,7 +119,7 @@ AppKit 侧:`NSVisualEffectView`,`blendingMode = .behindWindow`。
 
 | 状态 | 颜色 |
 |---|---|
-| 剩余 > 50% | normal:石墨灰(浅 `#6C6C70` / 深 `#98989D`),统一中性灰、不随服务色 |
+| 剩余 > 50% | normal:石墨灰(浅 `#6C6C70` / 深 `#D8D8D2`),统一中性灰、不随服务色 |
 | 剩余 20% ~ 50% | warning:浅色 `#F6C343` / 深色 `#FFE27A` |
 | 剩余 < 20% | low:浅色 `#FF7A2F` / 深色 `#FFA15F` |
 | 剩余 = 0 / 超限 | empty:浅色 `#FF4D6D` / 深色 `#FF7A90` |
@@ -343,7 +345,7 @@ prototype 里"色点"的实际形态分两种,**不要混用**:
 | Popover dense compact 周 bar | 3pt | 1.5pt |
 | Popover BigStat 主 bar | 6pt | 3pt |
 
-- 颜色:状态色;轨道 `.quaternarySystemFill`
+- 颜色:状态色;轨道默认 `Color.secondary.opacity(0.18)`,Popover 内显式使用 `CCPopoverPalette.progressTrack` 提高深色背景对比度
 - 标签:`Weekly · 周额度` 左对齐 caption + 百分比右对齐 caption .semibold tabular
 
 ### 11.5 KPI 大字 + Delta
@@ -385,7 +387,7 @@ prototype 里"色点"的实际形态分两种,**不要混用**:
 
 - **Toggle 颜色**:统一 `.toggleStyle(.switch).tint(.green)`,打开态走系统 `Color.green`(浅 `#30A14E` / 深 `#30D158`,见 §12.1)。Codex / Claude 账户开关也用绿色,**不**用产品识别色。这是「打开 = 启用 / 安全」的语义,产品识别色仅用于服务标识与按服务图表等数据可视化场景。
 - **hover 手型光标**:所有 `.borderless` / `.plain` 自定义按钮(Popover 顶部图标、Stats sidebar 条目、Onboarding 主次按钮、Settings 内 Account 行等)统一加 `pointingHandCursor()` ViewModifier(实现见 `Main/DesignSystem.swift`),鼠标进入时切换 `NSCursor.pointingHand`,离开时还原。系统原生 `.bordered` / `.borderedProminent` / `Toggle` / `Picker` **不**额外加,沿用系统行为。
-- **hover 背景**:仅 `PopoverIconButtonStyle`(Popover 顶部图标)采用浅灰圆角背景(`Color.primary.opacity(0.08)`,圆角 5pt)。其它按钮按各自的 hover 风格自治,不强制。
+- **hover 背景**:仅 `PopoverIconButtonStyle`(Popover 顶部图标)采用 `CCPopoverPalette.buttonHoverFill` 圆角背景(圆角 5pt)。其它按钮按各自的 hover 风格自治,不强制。
 
 ---
 
@@ -405,7 +407,7 @@ prototype 提供了 light + dark 两套效果(Canvas.html 左右对照)。绝大
 | 浅色填充 fill | `rgba(120,120,128,0.16/0.08/0.04)` | `rgba(120,120,128,0.24/0.16/0.08)` | `.quaternarySystemFill` 三档 |
 | Accent | `#007AFF` | `#0A84FF` | `.accentColor` / `Color.accentColor` |
 | System Green / Yellow / Orange / Red | 系统自适配 | 系统自适配 | `Color.green` / `Color.yellow` / `.orange` / `.red` |
-| Quota normal / warning / low / empty | `#6C6C70` / `#F6C343` / `#FF7A2F` / `#FF4D6D` | `#98989D` / `#FFE27A` / `#FFA15F` / `#FF7A90` | `statusColor(remainingPercent:tint:)` |
+| Quota normal / warning / low / empty | `#6C6C70` / `#F6C343` / `#FF7A2F` / `#FF4D6D` | `#D8D8D2` / `#FFE27A` / `#FFA15F` / `#FF7A90` | `statusColor(remainingPercent:tint:)` |
 | 窗口 / Popover / HUD 背景 | 浅色 frosted | 深色 frosted | `.background(.regularMaterial)` / `NSVisualEffectView` |
 
 ### 12.2 产品识别色(双套已定义,自动切换)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,8 +3,8 @@
 # build.sh — 命令行「不签名」构建 CCBar 并打包成可分发的 zip。
 #
 # 思路和主流免费开源 Mac App(如 Burrow)一致:不用付费证书、不做公证,
-# 用 CODE_SIGNING_ALLOWED=NO 让工具链自动给 arm64 打上 ad-hoc 签名,
-# 得到一个能在任意 Mac 上执行的 ad-hoc 包;用户首次手动去隔离一次即可。
+# 用 CODE_SIGNING_ALLOWED=NO 避开开发证书要求,构建完成后再显式 ad-hoc
+# 重签整个 .app,得到一个能在任意 Mac 上执行的 ad-hoc 包;用户首次手动去隔离一次即可。
 #
 # 相比 Xcode GUI 的 Archive 导出,这条路不会引入 "Apple Development" 开发证书,
 # 所以也不需要事后重签脚本。
@@ -25,7 +25,7 @@ APP="$BUILD_DIR/Build/Products/Release/CCBar.app"
 echo "==> [1/4] 清理旧构建"
 rm -rf "$BUILD_DIR"
 
-echo "==> [2/4] 编译(Release,不签名 → 自动 ad-hoc)"
+echo "==> [2/4] 编译(Release,不使用开发证书)"
 xcodebuild \
   -project ccbar.xcodeproj \
   -scheme ccbar \
@@ -36,11 +36,11 @@ xcodebuild \
 
 [[ -d "$APP" ]] || { echo "❌ 构建产物未找到: $APP" >&2; exit 1; }
 
-echo "==> [3/4] 清扩展属性并校验签名"
+echo "==> [3/4] 清扩展属性、ad-hoc 重签并校验"
 xattr -cr "$APP"
-codesign --verify --deep --strict --verbose=2 "$APP" \
-  && echo "   ✅ 签名校验通过" \
-  || echo "   ⚠️ 签名校验有告警(ad-hoc 包通常仍可正常运行,可忽略)"
+codesign --force --deep --sign - "$APP"
+codesign --verify --deep --strict --verbose=2 "$APP"
+echo "   ✅ 签名校验通过"
 codesign -dv --verbose=2 "$APP" 2>&1 | grep -E "Identifier|Signature" || true
 
 echo "==> [4/4] 打包"


### PR DESCRIPTION
## What changed

- Trigger an initial quota refresh during `AppState.bootstrap()` so the menu bar does not stay empty until the first scheduled interval.
- Resolve Claude Code display email from `oauthAccount.organizationName` when it contains an email, falling back to `emailAddress` / `email` when it does not.
- Disable automatic termination for the LSUIElement menu bar app so Release builds remain resident.
- Explicitly ad-hoc re-sign the built `.app` in `scripts/build.sh` after the unsigned Release build, and update docs/README to match the new runtime/build behavior.

## Why

On a fresh launch with a long refresh interval, the app can show empty quota data until the first scheduled tick. Also, Claude Code's keychain credential may not include an email; in that case `~/.claude.json` can expose both a login email and a subscription organization name. The organization name can be the quota-owning account, so the UI should prefer that email when present.

Release builds also needed an explicit ad-hoc re-sign after `CODE_SIGNING_ALLOWED=NO`; otherwise macOS may reject the app at launch despite a successful build.

## Validation

- Ran `./scripts/build.sh` successfully.
- Verified `codesign --verify --deep --strict --verbose=2 build/Build/Products/Release/CCBar.app` passes inside the build script.
- Launched the Release app with `open -n build/Build/Products/Release/CCBar.app` and confirmed the `CCBar` process remained running.
- Confirmed quota cache was populated from API data after launch.
