### PR TITLE
feat: 支持 Grok Build 额度与用量

### DIFF
--- a/CCBarApp.swift
+++ b/CCBarApp.swift
@@ -28,7 +28,7 @@ struct CCBarApp: App {
             OnboardingView()
                 .environment(appState)
         }
-        .defaultSize(width: 620, height: 520)
+        .defaultSize(width: 620, height: 560)
         .windowResizability(.contentSize)
     }
 }

--- a/CCBarTests/QuotaParsingTests.swift
+++ b/CCBarTests/QuotaParsingTests.swift
@@ -82,9 +82,10 @@ final class QuotaParsingTests: XCTestCase {
         XCTAssertEqual(entry.app, .grok)
         XCTAssertEqual(entry.model, "grok-4.5")
         XCTAssertEqual(entry.inputTokens, 600) // 1000 - 400 cache
-        XCTAssertEqual(entry.outputTokens, 150) // output + reasoning
+        XCTAssertEqual(entry.outputTokens, 150) // output + reasoning（用量可见）
         XCTAssertEqual(entry.cacheReadTokens, 400)
         XCTAssertEqual(entry.costUSD, Decimal(string: "1.5"))
+        XCTAssertNotNil(entry.costBreakdown)
         XCTAssertEqual(entry.conversationKey, "grok:sess-1")
         XCTAssertTrue(result.newSeenIds.contains("prompt-abc"))
 
@@ -97,6 +98,51 @@ final class QuotaParsingTests: XCTestCase {
         XCTAssertTrue(again.entries.isEmpty)
 
         try? FileManager.default.removeItem(at: root)
+    }
+
+    func testGrokTablePricingMatchesOfficialRatesWithoutReasoning() throws {
+        // billable 600 * $20/M + output 100 * $60/M + cache 400 * $3/M
+        // = 0.012 + 0.006 + 0.0012 = 0.0192
+        let usage = GrokJSONLScanner.TurnModelUsage(
+            model: "grok-4.5-build",
+            inputTokens: 1000,
+            outputTokens: 100,
+            cacheReadTokens: 400,
+            reasoningTokens: 9999, // 不计费
+            costUsdTicks: nil
+        )
+        let breakdown = try XCTUnwrap(GrokJSONLScanner.tableBreakdown(for: usage, at: Date()))
+        XCTAssertEqual(breakdown.input, Decimal(string: "0.012"))
+        XCTAssertEqual(breakdown.output, Decimal(string: "0.006"))
+        XCTAssertEqual(breakdown.cacheRead, Decimal(string: "0.0012"))
+        XCTAssertEqual(breakdown.total, Decimal(string: "0.0192"))
+
+        // ticks 权威费用缩放拆分
+        let priced = GrokJSONLScanner.resolveTurnCosts(
+            models: [usage],
+            totalTicks: 19_200_000, // $0.0192
+            at: Date()
+        )
+        XCTAssertEqual(priced.count, 1)
+        XCTAssertEqual(priced[0].costUSD, Decimal(string: "0.0192"))
+        XCTAssertEqual(priced[0].breakdown?.total, Decimal(string: "0.0192"))
+    }
+
+    func testGrokPriceAliasesNormalizeBuildVariants() {
+        XCTAssertEqual(Pricing.normalize(model: "grok-4.5-build"), "grok-4.5-build")
+        XCTAssertEqual(Pricing.normalize(model: "xai/grok-4.5"), "grok-4.5")
+        XCTAssertEqual(Pricing.normalize(model: "grok-4.20-0309-reasoning"), "grok-4.20-reasoning")
+        XCTAssertEqual(Pricing.normalize(model: "grok-code-fast-1-0825"), "grok-code-fast-1")
+        XCTAssertNotNil(Pricing.cost(
+            app: .grok,
+            model: "grok-4.5-build",
+            speed: .standard,
+            input: 1_000_000,
+            output: 0,
+            cacheRead: 0,
+            cacheCreation: 0,
+            at: Date()
+        ))
     }
 
     func testGrokBillingCreditsMapsWeeklyPrimaryAndProductLimits() {

--- a/CCBarTests/QuotaParsingTests.swift
+++ b/CCBarTests/QuotaParsingTests.swift
@@ -36,6 +36,69 @@ final class QuotaParsingTests: XCTestCase {
         XCTAssertNil(fetched.snapshot.weekly)
     }
 
+    func testGrokTurnCompletedUsageParsesTokensAndCostTicks() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ccbar-grok-scan-\(UUID().uuidString)", isDirectory: true)
+        let sessionDir = root
+            .appendingPathComponent("%2Ftmp%2Fdemo", isDirectory: true)
+            .appendingPathComponent("sess-1", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        let line: [String: Any] = [
+            "timestamp": 1_784_444_600.0,
+            "method": "_x.ai/session/update",
+            "params": [
+                "sessionId": "sess-1",
+                "update": [
+                    "sessionUpdate": "turn_completed",
+                    "prompt_id": "prompt-abc",
+                    "stop_reason": "end_turn",
+                    "usage": [
+                        "inputTokens": 1000,
+                        "outputTokens": 100,
+                        "cachedReadTokens": 400,
+                        "reasoningTokens": 50,
+                        "costUsdTicks": 1_500_000_000,
+                        "modelUsage": [
+                            "grok-4.5": [
+                                "inputTokens": 1000,
+                                "outputTokens": 100,
+                                "cachedReadTokens": 400,
+                                "reasoningTokens": 50,
+                                "costUsdTicks": 1_500_000_000
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: line)
+        var payload = data
+        payload.append(contentsOf: [0x0A])
+        try payload.write(to: sessionDir.appendingPathComponent("updates.jsonl"))
+
+        let result = GrokJSONLScanner.scan(previous: [:], seenPromptIds: [], root: root)
+        XCTAssertEqual(result.entries.count, 1)
+        let entry = try XCTUnwrap(result.entries.first)
+        XCTAssertEqual(entry.app, .grok)
+        XCTAssertEqual(entry.model, "grok-4.5")
+        XCTAssertEqual(entry.inputTokens, 600) // 1000 - 400 cache
+        XCTAssertEqual(entry.outputTokens, 150) // output + reasoning
+        XCTAssertEqual(entry.cacheReadTokens, 400)
+        XCTAssertEqual(entry.costUSD, Decimal(string: "1.5"))
+        XCTAssertEqual(entry.conversationKey, "grok:sess-1")
+        XCTAssertTrue(result.newSeenIds.contains("prompt-abc"))
+
+        // 增量：seen 后不应重复计费
+        let again = GrokJSONLScanner.scan(
+            previous: result.newState,
+            seenPromptIds: result.newSeenIds,
+            root: root
+        )
+        XCTAssertTrue(again.entries.isEmpty)
+
+        try? FileManager.default.removeItem(at: root)
+    }
+
     func testGrokBillingCreditsMapsWeeklyPrimaryAndProductLimits() {
         let root: [String: Any] = [
             "subscriptionTier": "SuperGrok",

--- a/CCBarTests/QuotaParsingTests.swift
+++ b/CCBarTests/QuotaParsingTests.swift
@@ -36,6 +36,44 @@ final class QuotaParsingTests: XCTestCase {
         XCTAssertNil(fetched.snapshot.weekly)
     }
 
+    func testGrokBillingCreditsMapsWeeklyPrimaryAndProductLimits() {
+        let root: [String: Any] = [
+            "subscriptionTier": "SuperGrok",
+            "config": [
+                "creditUsagePercent": 42.0,
+                "currentPeriod": [
+                    "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                    "start": "2026-07-27T02:22:31.057371+00:00",
+                    "end": "2026-08-03T02:22:31.057371+00:00"
+                ],
+                "billingPeriodStart": "2026-07-27T02:22:31.057371+00:00",
+                "billingPeriodEnd": "2026-08-03T02:22:31.057371+00:00",
+                "productUsage": [
+                    ["product": "GrokBuild", "usagePercent": 30.0],
+                    ["product": "Api", "usagePercent": 12.0],
+                    ["product": "GrokChat"]
+                ],
+                "isUnifiedBillingUser": true
+            ]
+        ]
+
+        let fetched = GrokQuotaClient.parse(root: root)
+        XCTAssertEqual(fetched.snapshot.app, .grok)
+        XCTAssertEqual(fetched.snapshot.primaryLimit?.kind, .weekly)
+        XCTAssertEqual(fetched.snapshot.primaryWindow?.usedPercent, 42)
+        XCTAssertEqual(fetched.snapshot.primaryWindow?.remainingPercent, 58)
+        XCTAssertNotNil(fetched.snapshot.primaryWindow?.resetsAt)
+        XCTAssertEqual(fetched.snapshot.planType, "SuperGrok")
+        XCTAssertEqual(fetched.planType, "SuperGrok")
+        XCTAssertEqual(fetched.snapshot.modelLimits.count, 3)
+        let names = Set(fetched.snapshot.modelLimits.compactMap(\.displayName))
+        XCTAssertTrue(names.contains("Grok Build"))
+        XCTAssertTrue(names.contains("API"))
+        XCTAssertTrue(names.contains("Grok Chat"))
+        let chat = fetched.snapshot.modelLimits.first { $0.displayName == "Grok Chat" }
+        XCTAssertEqual(chat?.window.usedPercent, 0)
+    }
+
     func testClaudeMergesLegacyWindowsAndDynamicFableLimit() {
         let root: [String: Any] = [
             "five_hour": ["utilization": 2.0, "resets_at": "2026-07-13T02:30:00.424333+00:00"],

--- a/CCBarTests/QuotaParsingTests.swift
+++ b/CCBarTests/QuotaParsingTests.swift
@@ -137,6 +137,37 @@ final class QuotaParsingTests: XCTestCase {
         XCTAssertEqual(chat?.window.usedPercent, 0)
     }
 
+    func testGrokSubscriptionTierMapsToDisplayName() {
+        XCTAssertEqual(
+            GrokQuotaClient.displayName(forTier: "SUBSCRIPTION_TIER_GROK_PRO"),
+            "SuperGrok"
+        )
+        XCTAssertEqual(
+            GrokQuotaClient.displayName(forTier: "SuperGrok"),
+            "SuperGrok"
+        )
+        XCTAssertEqual(
+            GrokQuotaClient.displayName(forProductId: "grok.pro.monthly.30.legacy"),
+            "SuperGrok"
+        )
+
+        let root: [String: Any] = [
+            "subscriptions": [
+                [
+                    "tier": "SUBSCRIPTION_TIER_GROK_PRO",
+                    "status": "SUBSCRIPTION_STATUS_ACTIVE",
+                    "apple": [
+                        "productId": "grok.pro.monthly.30.legacy"
+                    ]
+                ]
+            ]
+        ]
+        XCTAssertEqual(
+            GrokQuotaClient.parseSubscriptionDisplayName(root: root),
+            "SuperGrok"
+        )
+    }
+
     func testClaudeMergesLegacyWindowsAndDynamicFableLimit() {
         let root: [String: Any] = [
             "five_hour": ["utilization": 2.0, "resets_at": "2026-07-13T02:30:00.424333+00:00"],

--- a/Core/AppState.swift
+++ b/Core/AppState.swift
@@ -103,6 +103,7 @@ final class AppState {
 
     var codexTodayCost: Decimal?
     var claudeTodayCost: Decimal?
+    var grokTodayCost: Decimal?
 
     /// OpenAI / Anthropic statuspage.io 最新快照,失败时保留上一份。
     var codexServiceStatus: ServiceStatus?

--- a/Core/AppState.swift
+++ b/Core/AppState.swift
@@ -906,17 +906,50 @@ final class AppState {
 
     private func loadGrok() async {
         do {
-            let next = try await Task.detached(priority: .utility) {
+            var next = try await Task.detached(priority: .utility) {
                 try GrokAuth.load()
             }.value
             if grokIdentityChanged(previous: grokAccount, next: next) {
                 resetGrokQuotaState()
+            } else if next.planType == nil, let prevPlan = grokAccount?.planType {
+                // 重读 auth.json 不会带订阅档；保留上一次从 API 回填的 plan。
+                next.planType = prevPlan
             }
             self.grokAccount = next
             self.grokError = nil
+            // 设置页要立刻显示 subscription（类似 Claude 凭据里的 subscriptionType），
+            // 不必等周期性额度刷新。
+            await enrichGrokSubscriptionIfNeeded()
         } catch {
             self.grokAccount = nil
             self.grokError = "\(error)"
+        }
+    }
+
+    /// 用 `/rest/subscriptions` 补全 `planType`，失败静默（额度刷新仍会再试）。
+    private func enrichGrokSubscriptionIfNeeded() async {
+        guard var account = grokAccount, account.planType == nil,
+              let token = account.accessToken, !token.isEmpty
+        else { return }
+        // 先确保 token 可用，避免刚启动时 access 已过期。
+        let refreshed = await GrokTokenRefresher.ensureFreshAccessToken(account: &account)
+        let activeToken: String
+        switch refreshed {
+        case .success(let t):
+            activeToken = t
+            if t != grokAccount?.accessToken {
+                grokAccount = account
+            }
+        case .failure:
+            return
+        }
+        switch await GrokQuotaClient.fetchSubscriptionDisplayName(accessToken: activeToken) {
+        case .success(let plan):
+            guard var current = grokAccount else { return }
+            current.planType = plan
+            grokAccount = current
+        case .failure:
+            break
         }
     }
 
@@ -1065,10 +1098,7 @@ final class AppState {
         let result = await GrokQuotaClient.fetch(accessToken: activeToken)
         switch result {
         case .success(let fetched):
-            if account.planType == nil, let plan = fetched.planType {
-                account.planType = plan
-                grokAccount = account
-            } else if let plan = fetched.planType, account.planType != plan {
+            if let plan = fetched.planType, !plan.isEmpty, account.planType != plan {
                 account.planType = plan
                 grokAccount = account
             }

--- a/Core/AppState.swift
+++ b/Core/AppState.swift
@@ -9,8 +9,10 @@ final class AppState {
     var claudeAccount: ClaudeAccount?
     var antigravityAccount: AntigravityAccount?
     var antigravityAvailability: AntigravityAvailability = .notInstalled
+    var grokAccount: GrokAccount?
     var codexError: String?
     var claudeError: String?
+    var grokError: String?
 
     // MARK: 导入的 Codex 副账号
     //
@@ -45,6 +47,10 @@ final class AppState {
         get { quotaSnapshot(for: .antigravity) }
         set { updatePrimaryState(.antigravity) { $0.snapshot = newValue } }
     }
+    var grokQuota: QuotaSnapshot? {
+        get { quotaSnapshot(for: .grok) }
+        set { updatePrimaryState(.grok) { $0.snapshot = newValue } }
+    }
     var codexQuotaError: String? {
         get { quotaError(for: .codex) }
         set { updatePrimaryState(.codex) { $0.error = newValue } }
@@ -56,6 +62,10 @@ final class AppState {
     var antigravityQuotaError: String? {
         get { quotaError(for: .antigravity) }
         set { updatePrimaryState(.antigravity) { $0.error = newValue } }
+    }
+    var grokQuotaError: String? {
+        get { quotaError(for: .grok) }
+        set { updatePrimaryState(.grok) { $0.error = newValue } }
     }
     var codexQuotaSource: QuotaSnapshotSource? {
         get { quotaSource(for: .codex) }
@@ -69,6 +79,10 @@ final class AppState {
         get { quotaSource(for: .antigravity) }
         set { updatePrimaryState(.antigravity) { $0.source = newValue } }
     }
+    var grokQuotaSource: QuotaSnapshotSource? {
+        get { quotaSource(for: .grok) }
+        set { updatePrimaryState(.grok) { $0.source = newValue } }
+    }
     var codexRefreshState: QuotaRefreshState {
         get { refreshState(for: .codex) }
         set { updatePrimaryState(.codex) { $0.refresh = newValue } }
@@ -80,6 +94,10 @@ final class AppState {
     var antigravityRefreshState: QuotaRefreshState {
         get { refreshState(for: .antigravity) }
         set { updatePrimaryState(.antigravity) { $0.refresh = newValue } }
+    }
+    var grokRefreshState: QuotaRefreshState {
+        get { refreshState(for: .grok) }
+        set { updatePrimaryState(.grok) { $0.refresh = newValue } }
     }
     var quotaHistory = QuotaHistoryPayload()
 
@@ -125,6 +143,7 @@ final class AppState {
         await loadCodex()
         maybeShowKeychainPrompt()
         await loadClaude()
+        await loadGrok()
         antigravityAvailability = await AntigravityQuotaClient.detectAvailability()
         logCredentialSummary()
 
@@ -192,8 +211,10 @@ final class AppState {
     func refreshQuotas(reason: QuotaRefreshReason = .periodic) async {
         await loadCodex()
         await loadClaude()
+        await loadGrok()
         await loadCodexQuota(reason: reason)
         await loadClaudeQuota(reason: reason)
+        await loadGrokQuota(reason: reason)
         await loadAntigravityQuota(reason: reason)
         await loadAllImportedCodexQuotas(reason: reason)
         logQuotaSummary()
@@ -736,6 +757,16 @@ final class AppState {
         )
     }
 
+    private func recordGrokQuotaHistory(snapshot: QuotaSnapshot, sampledAt: Date) {
+        recordQuotaHistory(
+            accountKey: QuotaHistoryAccountKey.grokPrimary(userId: grokAccount?.userId),
+            app: .grok,
+            kind: .grokPrimary,
+            snapshot: snapshot,
+            sampledAt: sampledAt
+        )
+    }
+
     private func recordImportedCodexQuotaHistory(id: String, snapshot: QuotaSnapshot, sampledAt: Date) {
         recordQuotaHistory(
             accountKey: QuotaHistoryAccountKey.codexImported(id: id),
@@ -872,6 +903,39 @@ final class AppState {
         saveQuotaCache()
     }
 
+    private func loadGrok() async {
+        do {
+            let next = try await Task.detached(priority: .utility) {
+                try GrokAuth.load()
+            }.value
+            if grokIdentityChanged(previous: grokAccount, next: next) {
+                resetGrokQuotaState()
+            }
+            self.grokAccount = next
+            self.grokError = nil
+        } catch {
+            self.grokAccount = nil
+            self.grokError = "\(error)"
+        }
+    }
+
+    private func grokIdentityChanged(previous: GrokAccount?, next: GrokAccount) -> Bool {
+        guard let previous else { return false }
+        if let a = previous.userId, let b = next.userId, !a.isEmpty, !b.isEmpty {
+            return a != b
+        }
+        return previous.email != next.email
+    }
+
+    private func resetGrokQuotaState() {
+        grokQuota = nil
+        grokQuotaSource = nil
+        grokQuotaError = nil
+        grokRefreshState = QuotaRefreshState()
+        quotaCache.grok = nil
+        saveQuotaCache()
+    }
+
     private func loadCodexQuota(reason: QuotaRefreshReason) async {
         guard beginCodexRefresh(reason: reason) else { return }
         defer { codexRefreshState.inFlight = false }
@@ -962,6 +1026,54 @@ final class AppState {
             if reason == .userInitiated, claudeQuota == nil {
                 await loadClaudeCLIFallback(apiError: err)
             }
+        }
+    }
+
+    private func loadGrokQuota(reason: QuotaRefreshReason) async {
+        guard SettingsStore.shared.showGrok else { return }
+        guard beginGrokRefresh(reason: reason) else { return }
+        defer { grokRefreshState.inFlight = false }
+
+        guard var account = grokAccount else {
+            markGrokFailure("no grok account")
+            return
+        }
+        guard account.accessToken != nil else {
+            markGrokFailure(QuotaError.missingToken.description)
+            return
+        }
+        let refreshed = await GrokTokenRefresher.ensureFreshAccessToken(account: &account)
+        let activeToken: String
+        switch refreshed {
+        case .success(let t):
+            activeToken = t
+            if t != grokAccount?.accessToken {
+                grokAccount = account
+            }
+        case .failure(let err):
+            if err.isAuthRevoked {
+                markGrokFailure(
+                    "Grok 登录已失效,请在终端运行 grok login 重新登录后再回来刷新",
+                    error: err
+                )
+            } else {
+                markGrokFailure(err.description, error: err)
+            }
+            return
+        }
+        let result = await GrokQuotaClient.fetch(accessToken: activeToken)
+        switch result {
+        case .success(let fetched):
+            if account.planType == nil, let plan = fetched.planType {
+                account.planType = plan
+                grokAccount = account
+            } else if let plan = fetched.planType, account.planType != plan {
+                account.planType = plan
+                grokAccount = account
+            }
+            storeGrok(snapshot: fetched.snapshot, source: .api)
+        case .failure(let err):
+            markGrokFailure(err.description, error: err)
         }
     }
 
@@ -1063,6 +1175,24 @@ final class AppState {
         return true
     }
 
+    private func beginGrokRefresh(reason: QuotaRefreshReason) -> Bool {
+        let now = Date()
+        guard !grokRefreshState.inFlight else { return false }
+        if let backoffUntil = grokRefreshState.backoffUntil, backoffUntil > now {
+            markGrokFailure(backoffMessage(until: backoffUntil))
+            return false
+        }
+        if reason == .periodic,
+           let lastSuccessAt = grokRefreshState.lastSuccessAt,
+           now.timeIntervalSince(lastSuccessAt) < minSuccessInterval
+        {
+            return false
+        }
+        grokRefreshState.inFlight = true
+        grokRefreshState.lastAttemptAt = now
+        return true
+    }
+
     private func beginAntigravityRefresh(reason: QuotaRefreshReason) -> Bool {
         let now = Date()
         guard !antigravityRefreshState.inFlight else { return false }
@@ -1131,6 +1261,27 @@ final class AppState {
         saveQuotaCache()
     }
 
+    private func storeGrok(snapshot: QuotaSnapshot, source: QuotaSnapshotSource) {
+        let updatedAt = Date()
+        let mergedSnapshot = snapshot.preservingFutureResetDates(from: grokQuota, now: updatedAt)
+        grokQuota = mergedSnapshot
+        grokQuotaSource = source
+        grokQuotaError = nil
+        grokRefreshState.lastSuccessAt = updatedAt
+        grokRefreshState.lastError = nil
+        if source == .api {
+            grokRefreshState.backoffUntil = nil
+        }
+        grokRefreshState.source = source
+        quotaCache.grok = QuotaCacheRecord(
+            snapshot: mergedSnapshot,
+            source: source,
+            updatedAt: updatedAt
+        )
+        saveQuotaCache()
+        recordGrokQuotaHistory(snapshot: mergedSnapshot, sampledAt: updatedAt)
+    }
+
     private func markCodexFailure(_ message: String, error: QuotaError? = nil) {
         codexQuotaError = message
         codexRefreshState.lastError = message
@@ -1152,6 +1303,14 @@ final class AppState {
         antigravityRefreshState.lastError = message
         if error?.isRateLimited == true {
             antigravityRefreshState.backoffUntil = Date().addingTimeInterval(rateLimitBackoff)
+        }
+    }
+
+    private func markGrokFailure(_ message: String, error: QuotaError? = nil) {
+        grokQuotaError = message
+        grokRefreshState.lastError = message
+        if error?.isRateLimited == true {
+            grokRefreshState.backoffUntil = Date().addingTimeInterval(rateLimitBackoff)
         }
     }
 
@@ -1180,6 +1339,11 @@ final class AppState {
         case .unavailable(let detail):
             print("[Credentials 凭据] Antigravity 检测失败: \(detail)")
         }
+        if let g = grokAccount {
+            print("[Credentials 凭据] Grok: email=\(g.email ?? "—") plan=\(g.planType ?? "—") user_id=\(g.userId ?? "—") expiredGuess=\(g.expiredGuess) hasAccessToken=\(g.accessToken != nil)")
+        } else {
+            print("[Credentials 凭据] Grok 未加载: error=\(grokError ?? "unknown")")
+        }
     }
 
     private func logQuotaSummary() {
@@ -1200,6 +1364,14 @@ final class AppState {
             print("[Quota 额度] Antigravity: source=\(antigravityQuotaSource?.rawValue ?? "—") plan=\(q.planType ?? "—") \(format(q))")
         } else {
             print("[Quota 额度] Antigravity 拉取失败: error=\(antigravityQuotaError ?? "unknown")")
+        }
+        if let q = grokQuota {
+            print("[Quota 额度] Grok: source=\(grokQuotaSource?.rawValue ?? "—") plan=\(q.planType ?? "—") \(format(q))")
+            for limit in q.modelLimits {
+                print("       └─ \(limit.displayName ?? limit.id)=\(format(window: limit.window))")
+            }
+        } else {
+            print("[Quota 额度] Grok 拉取失败: error=\(grokQuotaError ?? "unknown")")
         }
     }
 

--- a/Core/Credentials/GrokAuth.swift
+++ b/Core/Credentials/GrokAuth.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// 读取 Grok Build CLI 凭据：`~/.grok/auth.json`（OIDC，issuer `https://auth.x.ai`）。
+enum GrokAuth {
+    nonisolated static func load() throws -> GrokAccount {
+        let url = authFileURL()
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw CredentialError.fileNotFound(url.path)
+        }
+        let data = try Data(contentsOf: url)
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any], !root.isEmpty else {
+            throw CredentialError.invalidJSON(url.path)
+        }
+
+        // 多 entry 时取 expires_at 最新的一条；同到期则按 key 排序取第一。
+        var best: (key: String, entry: [String: Any], expires: Date?)?
+        for (key, value) in root {
+            guard let entry = value as? [String: Any] else { continue }
+            guard nonEmpty(entry["key"] as? String) != nil else { continue }
+            let expires = parseDate(entry["expires_at"])
+            if let current = best {
+                let currentExp = current.expires ?? .distantPast
+                let nextExp = expires ?? .distantPast
+                if nextExp > currentExp || (nextExp == currentExp && key < current.key) {
+                    best = (key, entry, expires)
+                }
+            } else {
+                best = (key, entry, expires)
+            }
+        }
+        guard let best else {
+            throw CredentialError.decodeFailed("no grok auth entries in \(url.path)")
+        }
+
+        let entry = best.entry
+        let accessToken = nonEmpty(entry["key"] as? String)
+        let refreshToken = nonEmpty(entry["refresh_token"] as? String)
+        let email = nonEmpty(entry["email"] as? String)
+        let userId = nonEmpty(entry["user_id"] as? String)
+            ?? nonEmpty(entry["principal_id"] as? String)
+        let teamId = nonEmpty(entry["team_id"] as? String)
+        let clientId = nonEmpty(entry["oidc_client_id"] as? String)
+            ?? clientIdFromStorageKey(best.key)
+            ?? "b1a00492-073a-47ea-816f-4c329264a828"
+        let issuer = nonEmpty(entry["oidc_issuer"] as? String) ?? "https://auth.x.ai"
+        let expiresAt = best.expires
+            ?? accessToken.flatMap { JWT.decodePayload($0)?["exp"] as? Double }
+                .map { Date(timeIntervalSince1970: $0) }
+
+        let expiredGuess: Bool = {
+            if let expiresAt { return expiresAt < Date() }
+            return accessToken == nil
+        }()
+
+        return GrokAccount(
+            storageKey: best.key,
+            email: email,
+            userId: userId,
+            teamId: teamId,
+            planType: nil,
+            expiresAt: expiresAt,
+            expiredGuess: expiredGuess,
+            oidcIssuer: issuer,
+            oidcClientId: clientId,
+            accessToken: accessToken,
+            refreshToken: refreshToken
+        )
+    }
+
+    nonisolated static func authFileURL() -> URL {
+        if let home = ProcessInfo.processInfo.environment["GROK_HOME"], !home.isEmpty {
+            return URL(fileURLWithPath: home).appendingPathComponent("auth.json")
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".grok/auth.json")
+    }
+
+    nonisolated private static func clientIdFromStorageKey(_ key: String) -> String? {
+        // "https://auth.x.ai::b1a00492-..."
+        guard let range = key.range(of: "::", options: .backwards) else { return nil }
+        let id = String(key[range.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return id.isEmpty ? nil : id
+    }
+
+    nonisolated private static func parseDate(_ any: Any?) -> Date? {
+        if let s = any as? String {
+            let iso = ISO8601DateFormatter()
+            iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let d = iso.date(from: s) { return d }
+            iso.formatOptions = [.withInternetDateTime]
+            return iso.date(from: s)
+        }
+        if let n = any as? Double { return Date(timeIntervalSince1970: n) }
+        if let n = any as? Int { return Date(timeIntervalSince1970: Double(n)) }
+        return nil
+    }
+
+    nonisolated private static func nonEmpty(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+}

--- a/Core/Credentials/Models.swift
+++ b/Core/Credentials/Models.swift
@@ -34,6 +34,23 @@ struct ClaudeAccount: Sendable, Equatable {
     var refreshToken: String?
 }
 
+/// Grok Build / xAI CLI 登录态，对应 `~/.grok/auth.json`。
+struct GrokAccount: Sendable, Equatable {
+    /// auth.json 顶层 map 的 key，写回时用（如 `https://auth.x.ai::<client_id>`）
+    var storageKey: String
+    var email: String?
+    var userId: String?
+    var teamId: String?
+    var planType: String?
+    var expiresAt: Date?
+    var expiredGuess: Bool
+    var oidcIssuer: String
+    var oidcClientId: String
+    /// 仅内存使用，不打印 / 不持久化到 UserDefaults
+    var accessToken: String?
+    var refreshToken: String?
+}
+
 enum CredentialError: Error, CustomStringConvertible {
     case fileNotFound(String)
     case invalidJSON(String)

--- a/Core/Quota/GrokQuotaClient.swift
+++ b/Core/Quota/GrokQuotaClient.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// 拉取 Grok Build / SuperGrok 统一计费额度。
+///
+/// 端点与 Grok CLI 一致：`GET https://cli-chat-proxy.grok.com/v1/billing?format=credits`
+/// 响应核心字段：`config.creditUsagePercent` + 周窗口起止；可选 `productUsage` 分产品拆分。
+nonisolated enum GrokQuotaClient {
+    static let endpoint = URL(string: "https://cli-chat-proxy.grok.com/v1/billing?format=credits")!
+    private static let userAgent = "GrokCLI/0.2.112"
+
+    struct Fetched: Sendable {
+        var snapshot: QuotaSnapshot
+        var planType: String?
+    }
+
+    nonisolated static func fetch(accessToken: String) async -> Result<Fetched, QuotaError> {
+        var req = URLRequest(url: endpoint)
+        req.httpMethod = "GET"
+        req.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        req.setValue("cli", forHTTPHeaderField: "x-grok-client-mode")
+        req.setValue("0.2.112", forHTTPHeaderField: "x-grok-client-version")
+        req.timeoutInterval = 30
+
+        let data: Data
+        let resp: URLResponse
+        do {
+            (data, resp) = try await URLSession.shared.data(for: req)
+        } catch {
+            return .failure(.transport("\(error)"))
+        }
+        guard let http = resp as? HTTPURLResponse else {
+            return .failure(.transport("non-http"))
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let msg = String(data: data, encoding: .utf8) ?? ""
+            return .failure(.http(http.statusCode, msg))
+        }
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .failure(.decode("not json object"))
+        }
+        return .success(parse(root: root))
+    }
+
+    nonisolated static func parse(root: [String: Any]) -> Fetched {
+        let config = root["config"] as? [String: Any] ?? root
+        let usedPercent = number(config["creditUsagePercent"]) ?? 0
+        let period = config["currentPeriod"] as? [String: Any]
+        let periodEnd = parseDate(period?["end"])
+            ?? parseDate(config["billingPeriodEnd"])
+        let periodStart = parseDate(period?["start"])
+            ?? parseDate(config["billingPeriodStart"])
+        let windowSeconds: Int? = {
+            guard let start = periodStart, let end = periodEnd else {
+                // SuperGrok 统一计费默认周窗口
+                return 7 * 24 * 60 * 60
+            }
+            return max(1, Int(end.timeIntervalSince(start)))
+        }()
+
+        let weeklyWindow = QuotaWindow(
+            usedPercent: usedPercent,
+            resetsAt: periodEnd,
+            windowSeconds: windowSeconds
+        )
+        let primary = QuotaLimit.standard(
+            kind: .weekly,
+            window: weeklyWindow,
+            displayName: "Weekly credits"
+        )
+
+        var modelLimits: [QuotaLimit] = []
+        if let products = config["productUsage"] as? [[String: Any]] {
+            for row in products {
+                guard let product = nonEmpty(row["product"] as? String) else { continue }
+                // 部分产品只有名称、没有 usagePercent（未使用）
+                let pct = number(row["usagePercent"]) ?? 0
+                let limit = QuotaLimit.model(
+                    id: product.lowercased(),
+                    displayName: displayName(forProduct: product),
+                    window: QuotaWindow(
+                        usedPercent: pct,
+                        resetsAt: periodEnd,
+                        windowSeconds: windowSeconds
+                    ),
+                    isActive: true
+                )
+                modelLimits.append(limit)
+            }
+            modelLimits.sort { ($0.displayName ?? $0.id) < ($1.displayName ?? $1.id) }
+        }
+
+        let planType = nonEmpty(root["subscriptionTier"] as? String)
+            ?? nonEmpty(config["subscriptionTier"] as? String)
+
+        let snapshot = QuotaSnapshot(
+            app: .grok,
+            primaryLimit: primary,
+            secondaryLimit: nil,
+            modelLimits: modelLimits,
+            planType: planType,
+            fetchedAt: Date()
+        )
+        return Fetched(snapshot: snapshot, planType: planType)
+    }
+
+    nonisolated private static func displayName(forProduct product: String) -> String {
+        switch product.lowercased() {
+        case "grokbuild": return "Grok Build"
+        case "grokchat": return "Grok Chat"
+        case "api": return "API"
+        default: return product
+        }
+    }
+
+    nonisolated private static func number(_ any: Any?) -> Double? {
+        if let d = any as? Double { return d }
+        if let i = any as? Int { return Double(i) }
+        if let n = any as? NSNumber { return n.doubleValue }
+        if let s = any as? String, let d = Double(s) { return d }
+        return nil
+    }
+
+    nonisolated private static func parseDate(_ any: Any?) -> Date? {
+        if let s = any as? String {
+            let iso = ISO8601DateFormatter()
+            iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let d = iso.date(from: s) { return d }
+            iso.formatOptions = [.withInternetDateTime]
+            return iso.date(from: s)
+        }
+        if let n = any as? Double { return Date(timeIntervalSince1970: n) }
+        if let n = any as? Int { return Date(timeIntervalSince1970: Double(n)) }
+        return nil
+    }
+
+    nonisolated private static func nonEmpty(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+}

--- a/Core/Quota/GrokQuotaClient.swift
+++ b/Core/Quota/GrokQuotaClient.swift
@@ -1,11 +1,14 @@
 import Foundation
 
-/// 拉取 Grok Build / SuperGrok 统一计费额度。
+/// 拉取 Grok Build / SuperGrok 统一计费额度与订阅档位。
 ///
-/// 端点与 Grok CLI 一致：`GET https://cli-chat-proxy.grok.com/v1/billing?format=credits`
-/// 响应核心字段：`config.creditUsagePercent` + 周窗口起止；可选 `productUsage` 分产品拆分。
+/// - 额度：`GET https://cli-chat-proxy.grok.com/v1/billing?format=credits`
+/// - 订阅：`GET https://grok.com/rest/subscriptions`（`tier` 如 `SUBSCRIPTION_TIER_GROK_PRO`）
+///
+/// 部分 credits 响应会附带 `subscriptionTier`（与 Grok CLI 日志一致）；没有时回退到 subscriptions 接口。
 nonisolated enum GrokQuotaClient {
-    static let endpoint = URL(string: "https://cli-chat-proxy.grok.com/v1/billing?format=credits")!
+    static let billingEndpoint = URL(string: "https://cli-chat-proxy.grok.com/v1/billing?format=credits")!
+    static let subscriptionsEndpoint = URL(string: "https://grok.com/rest/subscriptions")!
     private static let userAgent = "GrokCLI/0.2.112"
 
     struct Fetched: Sendable {
@@ -14,33 +17,41 @@ nonisolated enum GrokQuotaClient {
     }
 
     nonisolated static func fetch(accessToken: String) async -> Result<Fetched, QuotaError> {
-        var req = URLRequest(url: endpoint)
-        req.httpMethod = "GET"
-        req.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        req.setValue("application/json", forHTTPHeaderField: "Accept")
-        req.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-        req.setValue("cli", forHTTPHeaderField: "x-grok-client-mode")
-        req.setValue("0.2.112", forHTTPHeaderField: "x-grok-client-version")
-        req.timeoutInterval = 30
+        async let billingResult = fetchJSON(url: billingEndpoint, accessToken: accessToken)
+        async let planResult = fetchSubscriptionDisplayName(accessToken: accessToken)
 
-        let data: Data
-        let resp: URLResponse
-        do {
-            (data, resp) = try await URLSession.shared.data(for: req)
-        } catch {
-            return .failure(.transport("\(error)"))
+        let billing: [String: Any]
+        switch await billingResult {
+        case .success(let root):
+            billing = root
+        case .failure(let err):
+            return .failure(err)
         }
-        guard let http = resp as? HTTPURLResponse else {
-            return .failure(.transport("non-http"))
+
+        var fetched = parse(root: billing)
+        // credits 响应里可能没有 subscriptionTier；用 subscriptions 接口补全。
+        if fetched.planType == nil, case .success(let plan) = await planResult {
+            fetched.planType = plan
+            var snapshot = fetched.snapshot
+            snapshot.planType = plan
+            fetched.snapshot = snapshot
         }
-        guard (200..<300).contains(http.statusCode) else {
-            let msg = String(data: data, encoding: .utf8) ?? ""
-            return .failure(.http(http.statusCode, msg))
+        return .success(fetched)
+    }
+
+    /// 单独拉订阅档位，供账号加载后尽快在设置页展示（不必等额度刷新）。
+    nonisolated static func fetchSubscriptionDisplayName(
+        accessToken: String
+    ) async -> Result<String, QuotaError> {
+        switch await fetchJSON(url: subscriptionsEndpoint, accessToken: accessToken) {
+        case .success(let root):
+            if let name = parseSubscriptionDisplayName(root: root) {
+                return .success(name)
+            }
+            return .failure(.decode("no active subscription tier"))
+        case .failure(let err):
+            return .failure(err)
         }
-        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return .failure(.decode("not json object"))
-        }
-        return .success(parse(root: root))
     }
 
     nonisolated static func parse(root: [String: Any]) -> Fetched {
@@ -92,7 +103,9 @@ nonisolated enum GrokQuotaClient {
         }
 
         let planType = nonEmpty(root["subscriptionTier"] as? String)
-            ?? nonEmpty(config["subscriptionTier"] as? String)
+            .map(displayName(forTier:))
+            ?? nonEmpty(config["subscriptionTier"] as? String).map(displayName(forTier:))
+            ?? parseSubscriptionDisplayName(root: root)
 
         let snapshot = QuotaSnapshot(
             app: .grok,
@@ -103,6 +116,101 @@ nonisolated enum GrokQuotaClient {
             fetchedAt: Date()
         )
         return Fetched(snapshot: snapshot, planType: planType)
+    }
+
+    /// 解析 `GET /rest/subscriptions` 或内嵌 subscriptions 数组，返回展示用订阅名。
+    nonisolated static func parseSubscriptionDisplayName(root: [String: Any]) -> String? {
+        let rows = root["subscriptions"] as? [[String: Any]] ?? []
+        // 优先 ACTIVE，其次取第一条有 tier 的
+        let ordered = rows.sorted { a, b in
+            let aActive = (a["status"] as? String)?.uppercased().contains("ACTIVE") == true
+            let bActive = (b["status"] as? String)?.uppercased().contains("ACTIVE") == true
+            if aActive != bActive { return aActive && !bActive }
+            return false
+        }
+        for row in ordered {
+            if let tier = nonEmpty(row["tier"] as? String) {
+                return displayName(forTier: tier)
+            }
+            if let apple = row["apple"] as? [String: Any],
+               let productId = nonEmpty(apple["productId"] as? String) {
+                return displayName(forProductId: productId)
+            }
+        }
+        return nil
+    }
+
+    /// `SUBSCRIPTION_TIER_GROK_PRO` / `SuperGrok` / `pro` → 设置页展示名。
+    nonisolated static func displayName(forTier raw: String) -> String {
+        let normalized = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .uppercased()
+            .replacingOccurrences(of: "-", with: "_")
+        let stripped = normalized
+            .replacingOccurrences(of: "SUBSCRIPTION_TIER_", with: "")
+            .replacingOccurrences(of: "SUBSCRIPTION_", with: "")
+
+        switch stripped {
+        case "GROK_PRO", "PRO", "SUPERGROK", "SUPER_GROK":
+            return "SuperGrok"
+        case "GROK_PRO_HEAVY", "PRO_HEAVY", "SUPERGROK_HEAVY", "HEAVY":
+            return "SuperGrok Heavy"
+        case "GROK_BASIC", "BASIC", "X_BASIC":
+            return "Basic"
+        case "FREE", "GROK_FREE":
+            return "Free"
+        default:
+            if stripped.isEmpty { return raw }
+            return stripped
+                .lowercased()
+                .split(separator: "_")
+                .map { $0.capitalized }
+                .joined(separator: " ")
+        }
+    }
+
+    nonisolated static func displayName(forProductId productId: String) -> String {
+        let id = productId.lowercased()
+        if id.contains("heavy") { return "SuperGrok Heavy" }
+        if id.contains("pro") || id.contains("super") { return "SuperGrok" }
+        if id.contains("basic") { return "Basic" }
+        if id.contains("free") { return "Free" }
+        return displayName(forTier: productId)
+    }
+
+    // MARK: - HTTP
+
+    nonisolated private static func fetchJSON(
+        url: URL,
+        accessToken: String
+    ) async -> Result<[String: Any], QuotaError> {
+        var req = URLRequest(url: url)
+        req.httpMethod = "GET"
+        req.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        req.setValue("cli", forHTTPHeaderField: "x-grok-client-mode")
+        req.setValue("0.2.112", forHTTPHeaderField: "x-grok-client-version")
+        req.timeoutInterval = 30
+
+        let data: Data
+        let resp: URLResponse
+        do {
+            (data, resp) = try await URLSession.shared.data(for: req)
+        } catch {
+            return .failure(.transport("\(error)"))
+        }
+        guard let http = resp as? HTTPURLResponse else {
+            return .failure(.transport("non-http"))
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let msg = String(data: data, encoding: .utf8) ?? ""
+            return .failure(.http(http.statusCode, msg))
+        }
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .failure(.decode("not json object"))
+        }
+        return .success(root)
     }
 
     nonisolated private static func displayName(forProduct product: String) -> String {

--- a/Core/Quota/GrokTokenRefresher.swift
+++ b/Core/Quota/GrokTokenRefresher.swift
@@ -1,0 +1,248 @@
+import Foundation
+import os
+
+/// 刷新 Grok Build OIDC access_token，并原子写回 `~/.grok/auth.json`。
+///
+/// 设计原则与 Claude 类似：只读监控、临期再刷、写回共享凭据文件时礼让 Grok CLI。
+nonisolated enum GrokTokenRefresher {
+    private static let log = Logger(subsystem: "com.cc-bar", category: "grok-refresh")
+    static let defaultTokenEndpoint = URL(string: "https://auth.x.ai/oauth2/token")!
+    /// 与 Claude 一样偏保守：30s skew，减少与 Grok CLI 争抢 refresh_token。
+    nonisolated static let refreshSkew: TimeInterval = 30
+
+    struct Refreshed: Sendable {
+        var accessToken: String
+        var refreshToken: String
+        var expiresAt: Date
+    }
+
+    nonisolated static func ensureFreshAccessToken(
+        account: inout GrokAccount
+    ) async -> Result<String, QuotaError> {
+        guard let current = account.accessToken else {
+            return .failure(.missingToken)
+        }
+        if !isExpired(expiresAt: account.expiresAt) {
+            return .success(current)
+        }
+        guard let refreshToken = account.refreshToken, !refreshToken.isEmpty else {
+            return .failure(.tokenRefreshFailed("no refresh_token"))
+        }
+        do {
+            let r = try await Coordinator.shared.refresh(
+                storageKey: account.storageKey,
+                clientId: account.oidcClientId,
+                issuer: account.oidcIssuer,
+                currentRefresh: refreshToken
+            )
+            account.accessToken = r.accessToken
+            account.refreshToken = r.refreshToken
+            account.expiresAt = r.expiresAt
+            account.expiredGuess = false
+            return .success(r.accessToken)
+        } catch let err as QuotaError {
+            return .failure(err)
+        } catch {
+            return .failure(.tokenRefreshFailed("\(error)"))
+        }
+    }
+
+    nonisolated static func isExpired(expiresAt: Date?, skew: TimeInterval = refreshSkew) -> Bool {
+        guard let expiresAt else {
+            // 无明确过期时间时按 JWT exp 再判断一次；仍没有则视为需要刷新。
+            return true
+        }
+        return expiresAt.timeIntervalSinceNow < skew
+    }
+
+    // MARK: - Coordinator
+
+    private actor Coordinator {
+        static let shared = Coordinator()
+        private var inFlight: Task<Refreshed, Error>?
+
+        func refresh(
+            storageKey: String,
+            clientId: String,
+            issuer: String,
+            currentRefresh: String
+        ) async throws -> Refreshed {
+            if let task = inFlight {
+                return try await task.value
+            }
+            let task = Task {
+                try await Coordinator.performRefresh(
+                    storageKey: storageKey,
+                    clientId: clientId,
+                    issuer: issuer,
+                    initialRefresh: currentRefresh
+                )
+            }
+            inFlight = task
+            defer { inFlight = nil }
+            return try await task.value
+        }
+
+        private static func performRefresh(
+            storageKey: String,
+            clientId: String,
+            issuer: String,
+            initialRefresh: String
+        ) async throws -> Refreshed {
+            var refreshToken = initialRefresh
+
+            // 发请求前重读文件：Grok CLI 可能已经刷过。
+            if let onDisk = GrokTokenRefresher.peekStored(storageKey: storageKey) {
+                if let exp = onDisk.expiresAt, !GrokTokenRefresher.isExpired(expiresAt: exp) {
+                    return Refreshed(
+                        accessToken: onDisk.accessToken,
+                        refreshToken: onDisk.refreshToken ?? refreshToken,
+                        expiresAt: exp
+                    )
+                }
+                if let onDiskRefresh = onDisk.refreshToken, !onDiskRefresh.isEmpty {
+                    refreshToken = onDiskRefresh
+                }
+            }
+
+            let refreshed = try await GrokTokenRefresher.performNetworkRefresh(
+                using: refreshToken,
+                clientId: clientId,
+                issuer: issuer
+            )
+            try GrokTokenRefresher.writeBack(
+                storageKey: storageKey,
+                refreshed: refreshed
+            )
+            return refreshed
+        }
+    }
+
+    // MARK: - Network
+
+    nonisolated static func performNetworkRefresh(
+        using refreshToken: String,
+        clientId: String,
+        issuer: String
+    ) async throws -> Refreshed {
+        let endpoint = tokenEndpoint(for: issuer)
+        var req = URLRequest(url: endpoint)
+        req.httpMethod = "POST"
+        req.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        let body = "grant_type=refresh_token"
+            + "&refresh_token=\(percent(refreshToken))"
+            + "&client_id=\(percent(clientId))"
+        req.httpBody = body.data(using: .utf8)
+
+        let data: Data
+        let resp: URLResponse
+        do {
+            (data, resp) = try await URLSession.shared.data(for: req)
+        } catch {
+            throw QuotaError.tokenRefreshFailed("transport: \(error)")
+        }
+        guard let http = resp as? HTTPURLResponse else {
+            throw QuotaError.tokenRefreshFailed("non-http response")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let msg = String(data: data, encoding: .utf8) ?? ""
+            if http.statusCode == 400 || http.statusCode == 401 {
+                if msg.localizedCaseInsensitiveContains("invalid_grant")
+                    || msg.localizedCaseInsensitiveContains("invalid_token") {
+                    throw QuotaError.tokenRevoked
+                }
+            }
+            throw QuotaError.tokenRefreshFailed("http \(http.statusCode): \(msg)")
+        }
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let newAccess = root["access_token"] as? String
+        else {
+            throw QuotaError.tokenRefreshFailed("invalid json / no access_token")
+        }
+        let newRefresh = (root["refresh_token"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+            ?? refreshToken
+        let expiresAt: Date = {
+            if let seconds = root["expires_in"] as? Double {
+                return Date().addingTimeInterval(seconds)
+            }
+            if let seconds = root["expires_in"] as? Int {
+                return Date().addingTimeInterval(TimeInterval(seconds))
+            }
+            if let exp = JWT.decodePayload(newAccess)?["exp"] as? Double {
+                return Date(timeIntervalSince1970: exp)
+            }
+            return Date().addingTimeInterval(6 * 3600)
+        }()
+        return Refreshed(accessToken: newAccess, refreshToken: newRefresh, expiresAt: expiresAt)
+    }
+
+    nonisolated private static func tokenEndpoint(for issuer: String) -> URL {
+        let trimmed = issuer.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        if let url = URL(string: "\(trimmed)/oauth2/token") {
+            return url
+        }
+        return defaultTokenEndpoint
+    }
+
+    // MARK: - Disk
+
+    struct StoredSnapshot: Sendable {
+        var accessToken: String
+        var refreshToken: String?
+        var expiresAt: Date?
+    }
+
+    nonisolated static func peekStored(storageKey: String) -> StoredSnapshot? {
+        let url = GrokAuth.authFileURL()
+        guard let data = try? Data(contentsOf: url),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let entry = root[storageKey] as? [String: Any],
+              let access = entry["key"] as? String,
+              !access.isEmpty
+        else { return nil }
+        let refresh = entry["refresh_token"] as? String
+        let expiresAt = parseDate(entry["expires_at"])
+            ?? JWT.decodePayload(access).flatMap { ($0["exp"] as? Double).map { Date(timeIntervalSince1970: $0) } }
+        return StoredSnapshot(accessToken: access, refreshToken: refresh, expiresAt: expiresAt)
+    }
+
+    nonisolated static func writeBack(storageKey: String, refreshed: Refreshed) throws {
+        let url = GrokAuth.authFileURL()
+        var root: [String: Any] = [:]
+        if let data = try? Data(contentsOf: url),
+           let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            root = obj
+        }
+        var entry = root[storageKey] as? [String: Any] ?? [:]
+        entry["key"] = refreshed.accessToken
+        entry["refresh_token"] = refreshed.refreshToken
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        entry["expires_at"] = iso.string(from: refreshed.expiresAt)
+        root[storageKey] = entry
+
+        let out = try JSONSerialization.data(
+            withJSONObject: root,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try out.write(to: url, options: [.atomic])
+        log.info("wrote refreshed grok tokens to auth.json")
+    }
+
+    nonisolated private static func parseDate(_ any: Any?) -> Date? {
+        if let s = any as? String {
+            let iso = ISO8601DateFormatter()
+            iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let d = iso.date(from: s) { return d }
+            iso.formatOptions = [.withInternetDateTime]
+            return iso.date(from: s)
+        }
+        if let n = any as? Double { return Date(timeIntervalSince1970: n) }
+        return nil
+    }
+
+    nonisolated private static func percent(_ s: String) -> String {
+        s.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? s
+    }
+}

--- a/Core/Quota/QuotaModels.swift
+++ b/Core/Quota/QuotaModels.swift
@@ -48,7 +48,7 @@ nonisolated struct QuotaProviderDescriptor: Sendable, Hashable, Identifiable {
             vendor: "xAI",
             logoName: "grok",
             fallback: "G",
-            supportsLocalCost: false
+            supportsLocalCost: true
         ),
     ]
 }

--- a/Core/Quota/QuotaModels.swift
+++ b/Core/Quota/QuotaModels.swift
@@ -4,6 +4,7 @@ nonisolated enum QuotaApp: String, Sendable, Codable, CaseIterable, Hashable {
     case codex
     case claude
     case antigravity
+    case grok
 }
 
 nonisolated struct QuotaProviderDescriptor: Sendable, Hashable, Identifiable {
@@ -39,6 +40,14 @@ nonisolated struct QuotaProviderDescriptor: Sendable, Hashable, Identifiable {
             vendor: "Google",
             logoName: "antigravity",
             fallback: "A",
+            supportsLocalCost: false
+        ),
+        QuotaProviderDescriptor(
+            app: .grok,
+            title: "Grok",
+            vendor: "xAI",
+            logoName: "grok",
+            fallback: "G",
             supportsLocalCost: false
         ),
     ]
@@ -363,7 +372,7 @@ nonisolated enum QuotaError: Error, CustomStringConvertible {
         case .decode(let msg): return "decode: \(msg)"
         case .tokenRefreshFailed(let msg): return "token refresh failed: \(msg)"
         case .tokenRevoked:
-            return "Claude 登录已失效,请在终端运行 claude 重新登录后再回来刷新"
+            return "登录已失效,请在终端重新登录后再回来刷新"
         }
     }
 

--- a/Core/Storage/QuotaCache.swift
+++ b/Core/Storage/QuotaCache.swift
@@ -30,6 +30,11 @@ nonisolated struct QuotaCachePayload: Sendable, Equatable, Codable {
         set { providers[.antigravity] = newValue }
     }
 
+    var grok: QuotaCacheRecord? {
+        get { providers[.grok] }
+        set { providers[.grok] = newValue }
+    }
+
     private enum CodingKeys: String, CodingKey {
         case version
         case providers

--- a/Core/Storage/QuotaHistoryStore.swift
+++ b/Core/Storage/QuotaHistoryStore.swift
@@ -4,6 +4,7 @@ nonisolated enum QuotaHistoryAccountKind: String, Sendable, Codable {
     case codexPrimary
     case codexImported
     case claudePrimary
+    case grokPrimary
 }
 
 nonisolated struct QuotaHistorySample: Sendable, Equatable, Codable {
@@ -54,6 +55,13 @@ enum QuotaHistoryAccountKey {
 
     nonisolated static func claudePrimary() -> String {
         "claude:primary"
+    }
+
+    nonisolated static func grokPrimary(userId: String?) -> String {
+        if let id = nonEmpty(userId) {
+            return "grok:primary:\(id)"
+        }
+        return "grok:primary"
     }
 
     nonisolated private static func nonEmpty(_ value: String?) -> String? {

--- a/Core/Storage/ScanCache.swift
+++ b/Core/Storage/ScanCache.swift
@@ -20,16 +20,19 @@ nonisolated struct ScanFileState: Sendable, Equatable, Codable {
 
 nonisolated struct ScanState: Sendable, Equatable, Codable {
     /// version 管「结构变更」（字段增减导致解码不兼容时 bump）；价格变更由 pricingFingerprint 接管。
-    /// v9: Claude 流式半成品不再入账；旧 seen / rollup 可能已污染，必须全量重建。
-    static let currentVersion: Int = 9
+    /// v10: 接入 Grok Build 本地用量扫描（`~/.grok/sessions/**/updates.jsonl`）。
+    static let currentVersion: Int = 10
     var version: Int = ScanState.currentVersion
     var generationID: String = ""
     /// 写盘时记录的价格指纹；load 时与当前 `Pricing.fingerprint(knownModels:)` 不一致即视为缓存失效、全量重扫重算。
     var pricingFingerprint: String = ""
     var claude: [String: ScanFileState] = [:]
     var codex: [String: ScanFileState] = [:]
+    var grok: [String: ScanFileState] = [:]
     /// 跨文件的 Claude message.id 去重集合（同一条 assistant 消息可能被 sidechain / subagent 在多个 jsonl 里重复引用）。
     var claudeSeenMessageIds: [String] = []
+    /// Grok turn_completed 的 prompt_id 去重（主会话 / subagent 可能重复写同一 turn）。
+    var grokSeenPromptIds: [String] = []
 }
 
 /// 扫描缓存的读取结论。缓存文件缺失、损坏、版本不符或价格指纹变化都必须显式标为失效，
@@ -95,8 +98,8 @@ enum ScanCache {
 /// 聚合结果磁盘缓存，启动后立刻 UI 有数。
 nonisolated struct UsageRollupPayload: Sendable, Codable {
     /// version 管「结构变更」；价格变更由 pricingFingerprint 接管。
-    /// v8: 配合 ScanState v9 清除曾被提前入账的 Claude 流式半成品。
-    static let currentVersion: Int = 8
+    /// v9: 配合 ScanState v10 接入 Grok 本地用量。
+    static let currentVersion: Int = 9
     var version: Int = UsageRollupPayload.currentVersion
     var generationID: String = ""
     /// 写盘时记录的价格指纹；load 时与当前 `Pricing.fingerprint(knownModels:)` 不一致即丢弃，全量重扫重建。

--- a/Core/Storage/Settings.swift
+++ b/Core/Storage/Settings.swift
@@ -124,6 +124,10 @@ final class SettingsStore {
         get { isProviderEnabled(.antigravity) }
         set { setProviderEnabled(newValue, for: .antigravity) }
     }
+    var showGrok: Bool {
+        get { isProviderEnabled(.grok) }
+        set { setProviderEnabled(newValue, for: .grok) }
+    }
     var menuBarShowCodex: Bool {
         get { isProviderShownInMenuBar(.codex) }
         set { setProviderShownInMenuBar(newValue, for: .codex) }
@@ -135,6 +139,10 @@ final class SettingsStore {
     var menuBarShowAntigravity: Bool {
         get { isProviderShownInMenuBar(.antigravity) }
         set { setProviderShownInMenuBar(newValue, for: .antigravity) }
+    }
+    var menuBarShowGrok: Bool {
+        get { isProviderShownInMenuBar(.grok) }
+        set { setProviderShownInMenuBar(newValue, for: .grok) }
     }
 
     // 菜单栏
@@ -153,6 +161,10 @@ final class SettingsStore {
     var floatingShowAntigravity: Bool {
         get { isProviderShownInFloatingHUD(.antigravity) }
         set { setProviderShownInFloatingHUD(newValue, for: .antigravity) }
+    }
+    var floatingShowGrok: Bool {
+        get { isProviderShownInFloatingHUD(.grok) }
+        set { setProviderShownInFloatingHUD(newValue, for: .grok) }
     }
 
     // 刷新
@@ -280,6 +292,7 @@ final class SettingsStore {
                 floatingHUD: defaults.object(forKey: Keys.floatingShowClaude) as? Bool ?? true
             ),
             .antigravity: .enabledByDefault,
+            .grok: .enabledByDefault,
         ]
     }
 

--- a/Core/Usage/GrokJSONLScanner.swift
+++ b/Core/Usage/GrokJSONLScanner.swift
@@ -7,7 +7,8 @@ import Foundation
 /// - 子 agent：`.../subagents/<id>/updates.jsonl`
 /// - 事件：`method` 为 `_x.ai/session/update`，`sessionUpdate == turn_completed`
 /// - 去重：`prompt_id`（同一 turn 只计一次）
-/// - 花费：优先 `costUsdTicks`（1 tick = 1e-9 USD），否则走 `Pricing` 本地表
+/// - 花费：优先 `costUsdTicks`（1 tick = 1e-9 USD，与官方 API 价一致），否则走 `Pricing` 本地表
+/// - 计费口径（与 ticks 校验一致）：billable_input + output（不含 reasoning）+ cache_read
 enum GrokJSONLScanner {
     /// costUsdTicks → USD 的换算：1e9 ticks = $1
     nonisolated static let ticksPerUSD: Decimal = 1_000_000_000
@@ -102,20 +103,20 @@ enum GrokJSONLScanner {
                     seen.insert(turn.promptID)
 
                     let day = UsageDay.startOfDay(for: turn.timestamp)
-                    for modelUsage in turn.models {
+                    // 多模型 turn：若仅有合计 ticks，按价表估算比例拆分；单模型直接用自身 ticks。
+                    let modelCosts = resolveTurnCosts(
+                        models: turn.models,
+                        totalTicks: turn.totalCostUsdTicks,
+                        at: turn.timestamp
+                    )
+                    for (index, modelUsage) in turn.models.enumerated() {
                         let model = Pricing.normalize(model: modelUsage.model)
                         let cacheRead = modelUsage.cacheReadTokens
                         // Grok 的 inputTokens 含 cachedRead；用量表记非缓存输入。
                         let input = max(0, modelUsage.inputTokens - cacheRead)
+                        // Token 统计保留 reasoning（用量可见）；计费见 resolveCost。
                         let output = modelUsage.outputTokens + modelUsage.reasoningTokens
-                        let costUSD = resolveCost(
-                            ticks: modelUsage.costUsdTicks ?? turn.totalCostUsdTicks,
-                            model: model,
-                            input: input,
-                            output: output,
-                            cacheRead: cacheRead,
-                            at: turn.timestamp
-                        )
+                        let priced = modelCosts[index]
                         entries.append(UsageEntry(
                             app: .grok,
                             conversationKey: conversationKey,
@@ -127,8 +128,8 @@ enum GrokJSONLScanner {
                             outputTokens: output,
                             cacheReadTokens: cacheRead,
                             cacheCreationTokens: 0,
-                            costUSD: costUSD,
-                            costBreakdown: nil
+                            costUSD: priced.costUSD,
+                            costBreakdown: priced.breakdown
                         ))
                     }
                 }
@@ -155,7 +156,7 @@ enum GrokJSONLScanner {
 
     // MARK: - Parse
 
-    private struct TurnModelUsage: Sendable {
+    struct TurnModelUsage: Sendable {
         var model: String
         var inputTokens: Int
         var outputTokens: Int
@@ -236,26 +237,111 @@ enum GrokJSONLScanner {
         )]
     }
 
-    nonisolated private static func resolveCost(
-        ticks: Int64?,
-        model: String,
-        input: Int,
-        output: Int,
-        cacheRead: Int,
+    struct PricedModel: Sendable {
+        var costUSD: Decimal?
+        var breakdown: CostBreakdown?
+    }
+
+    /// 为 turn 内每个模型解析费用。
+    /// - 有 per-model ticks：直接用（权威）
+    /// - 仅有 total ticks：按价表估算比例拆分
+    /// - 都没有：价表回退（reasoning 不计费）
+    nonisolated static func resolveTurnCosts(
+        models: [TurnModelUsage],
+        totalTicks: Int64?,
         at date: Date
-    ) -> Decimal? {
-        if let ticks, ticks > 0 {
-            return Decimal(ticks) / ticksPerUSD
+    ) -> [PricedModel] {
+        let estimates: [CostBreakdown?] = models.map { m in
+            tableBreakdown(for: m, at: date)
         }
-        return Pricing.cost(
+        let perModelTicks: [Decimal?] = models.map { m in
+            guard let t = m.costUsdTicks, t > 0 else { return nil }
+            return Decimal(t) / ticksPerUSD
+        }
+
+        // 1) 每个模型自带 ticks
+        if perModelTicks.allSatisfy({ $0 != nil }) {
+            return zip(perModelTicks, estimates).map { ticksUSD, est in
+                scaledBreakdown(target: ticksUSD!, estimate: est)
+            }
+        }
+
+        // 2) 部分有 ticks：有的用 ticks，没有的用价表
+        if perModelTicks.contains(where: { $0 != nil }) {
+            return zip(perModelTicks, estimates).map { ticksUSD, est in
+                if let ticksUSD {
+                    return scaledBreakdown(target: ticksUSD, estimate: est)
+                }
+                return PricedModel(costUSD: est?.total, breakdown: est)
+            }
+        }
+
+        // 3) 仅合计 ticks：按价表比例分摊
+        if let totalTicks, totalTicks > 0 {
+            let totalUSD = Decimal(totalTicks) / ticksPerUSD
+            let weights = estimates.map { $0?.total ?? 0 }
+            let weightSum = weights.reduce(0, +)
+            if weightSum > 0 {
+                return zip(weights, estimates).map { w, est in
+                    let share = totalUSD * w / weightSum
+                    return scaledBreakdown(target: share, estimate: est)
+                }
+            }
+            // 无价表权重时均分
+            let share = totalUSD / Decimal(max(models.count, 1))
+            return models.map { _ in
+                PricedModel(
+                    costUSD: share,
+                    breakdown: CostBreakdown(input: share, output: 0, cacheRead: 0, cacheCreation: 0)
+                )
+            }
+        }
+
+        // 4) 纯价表
+        return estimates.map { PricedModel(costUSD: $0?.total, breakdown: $0) }
+    }
+
+    /// 价表估算：billable input + **output（不含 reasoning）** + cache。
+    nonisolated static func tableBreakdown(
+        for modelUsage: TurnModelUsage,
+        at date: Date
+    ) -> CostBreakdown? {
+        let cacheRead = modelUsage.cacheReadTokens
+        let input = max(0, modelUsage.inputTokens - cacheRead)
+        // reasoning 经本地校验不计入 ticks/官方计费
+        let billedOutput = modelUsage.outputTokens
+        return Pricing.costBreakdown(
             app: .grok,
-            model: model,
+            model: modelUsage.model,
             speed: .standard,
             input: input,
-            output: output,
+            output: billedOutput,
             cacheRead: cacheRead,
             cacheCreation: 0,
             at: date
+        )
+    }
+
+    /// 把价表拆分按比例缩放到目标总额（通常是 ticks 换算的权威费用）。
+    nonisolated static func scaledBreakdown(
+        target: Decimal,
+        estimate: CostBreakdown?
+    ) -> PricedModel {
+        guard let estimate, estimate.total > 0 else {
+            return PricedModel(
+                costUSD: target,
+                breakdown: CostBreakdown(input: target, output: 0, cacheRead: 0, cacheCreation: 0)
+            )
+        }
+        let scale = target / estimate.total
+        return PricedModel(
+            costUSD: target,
+            breakdown: CostBreakdown(
+                input: estimate.input * scale,
+                output: estimate.output * scale,
+                cacheRead: estimate.cacheRead * scale,
+                cacheCreation: estimate.cacheCreation * scale
+            )
         )
     }
 

--- a/Core/Usage/GrokJSONLScanner.swift
+++ b/Core/Usage/GrokJSONLScanner.swift
@@ -1,0 +1,385 @@
+import Foundation
+
+/// 扫 `~/.grok/sessions/**/updates.jsonl`，把 `turn_completed` 的 usage 解析成 UsageEntry。
+///
+/// 数据源与 Grok Build CLI 一致：
+/// - 路径：`~/.grok/sessions/<url-encoded-cwd>/<session-id>/updates.jsonl`
+/// - 子 agent：`.../subagents/<id>/updates.jsonl`
+/// - 事件：`method` 为 `_x.ai/session/update`，`sessionUpdate == turn_completed`
+/// - 去重：`prompt_id`（同一 turn 只计一次）
+/// - 花费：优先 `costUsdTicks`（1 tick = 1e-9 USD），否则走 `Pricing` 本地表
+enum GrokJSONLScanner {
+    /// costUsdTicks → USD 的换算：1e9 ticks = $1
+    nonisolated static let ticksPerUSD: Decimal = 1_000_000_000
+
+    struct Result: Sendable {
+        var entries: [UsageEntry]
+        var conversationSeeds: [ConversationSeed]
+        var newState: [String: ScanFileState]
+        var newSeenIds: [String]
+        var filesScanned: Int
+        var linesParsed: Int
+    }
+
+    nonisolated static func scan(previous: [String: ScanFileState], seenPromptIds: [String]) -> Result {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let root = home.appendingPathComponent(".grok/sessions", isDirectory: true)
+        return scan(previous: previous, seenPromptIds: seenPromptIds, root: root)
+    }
+
+    /// 可注入 root，供测试。
+    nonisolated static func scan(
+        previous: [String: ScanFileState],
+        seenPromptIds: [String],
+        root: URL
+    ) -> Result {
+        let allJSONL = JSONLDirectoryEnumerator.files(at: root)
+        // 只扫 updates.jsonl（主会话与 subagent 均用此文件名）
+        let files = allJSONL.filter { $0.lastPathComponent == "updates.jsonl" }
+
+        var newState: [String: ScanFileState] = previous
+        var entries: [UsageEntry] = []
+        var linesParsed = 0
+        var seeds: [String: ConversationSeed] = [:]
+        var seen = Set(seenPromptIds)
+
+        for url in files {
+            let path = url.path
+            let attrs = try? FileManager.default.attributesOfItem(atPath: path)
+            let mtime = (attrs?[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+            let size = (attrs?[.size] as? NSNumber)?.uint64Value ?? 0
+
+            var state = previous[path] ?? ScanFileState(mtime: 0, offset: 0)
+            if state.mtime == mtime, state.offset == size {
+                newState[path] = state
+                // 未变文件也补 seed，便于对话列表展示标题/项目
+                if let id = state.conversationID {
+                    let key = "grok:\(id)"
+                    if seeds[key] == nil {
+                        seeds[key] = seed(
+                            sessionID: id,
+                            path: path,
+                            title: state.fallbackTitle,
+                            cwd: state.conversationCwd
+                        )
+                    }
+                }
+                continue
+            }
+            if state.offset > size {
+                state.offset = 0
+            }
+
+            guard let read = JSONLLineReader.read(url: url, fromOffset: state.offset) else {
+                newState[path] = state
+                continue
+            }
+
+            let meta = sessionMeta(for: url)
+            if state.conversationID == nil {
+                state.conversationID = meta.sessionID
+            }
+            if state.conversationCwd == nil || state.conversationCwd?.isEmpty == true {
+                state.conversationCwd = meta.cwd
+            }
+            if state.fallbackTitle == nil {
+                state.fallbackTitle = meta.title
+            }
+            let sessionID = state.conversationID ?? meta.sessionID
+            let conversationKey = "grok:\(sessionID)"
+            seeds[conversationKey] = seed(
+                sessionID: sessionID,
+                path: path,
+                title: state.fallbackTitle ?? meta.title,
+                cwd: state.conversationCwd ?? meta.cwd
+            )
+
+            for line in read.lines {
+                linesParsed += 1
+                guard let turns = parseTurnCompleted(line) else { continue }
+                for turn in turns {
+                    if seen.contains(turn.promptID) { continue }
+                    seen.insert(turn.promptID)
+
+                    let day = UsageDay.startOfDay(for: turn.timestamp)
+                    for modelUsage in turn.models {
+                        let model = Pricing.normalize(model: modelUsage.model)
+                        let cacheRead = modelUsage.cacheReadTokens
+                        // Grok 的 inputTokens 含 cachedRead；用量表记非缓存输入。
+                        let input = max(0, modelUsage.inputTokens - cacheRead)
+                        let output = modelUsage.outputTokens + modelUsage.reasoningTokens
+                        let costUSD = resolveCost(
+                            ticks: modelUsage.costUsdTicks ?? turn.totalCostUsdTicks,
+                            model: model,
+                            input: input,
+                            output: output,
+                            cacheRead: cacheRead,
+                            at: turn.timestamp
+                        )
+                        entries.append(UsageEntry(
+                            app: .grok,
+                            conversationKey: conversationKey,
+                            model: model,
+                            speed: .standard,
+                            day: day,
+                            timestamp: turn.timestamp,
+                            inputTokens: input,
+                            outputTokens: output,
+                            cacheReadTokens: cacheRead,
+                            cacheCreationTokens: 0,
+                            costUSD: costUSD,
+                            costBreakdown: nil
+                        ))
+                    }
+                }
+            }
+
+            state.mtime = mtime
+            state.offset = read.newOffset
+            newState[path] = state
+        }
+
+        // 清理已消失的文件 watermark
+        let live = Set(files.map(\.path))
+        newState = newState.filter { live.contains($0.key) }
+
+        return Result(
+            entries: entries,
+            conversationSeeds: Array(seeds.values),
+            newState: newState,
+            newSeenIds: Array(seen),
+            filesScanned: files.count,
+            linesParsed: linesParsed
+        )
+    }
+
+    // MARK: - Parse
+
+    private struct TurnModelUsage: Sendable {
+        var model: String
+        var inputTokens: Int
+        var outputTokens: Int
+        var cacheReadTokens: Int
+        var reasoningTokens: Int
+        var costUsdTicks: Int64?
+    }
+
+    private struct TurnUsage: Sendable {
+        var promptID: String
+        var timestamp: Date
+        var models: [TurnModelUsage]
+        var totalCostUsdTicks: Int64?
+    }
+
+    nonisolated private static func parseTurnCompleted(_ line: String) -> [TurnUsage]? {
+        guard let data = line.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+
+        // 兼容 method 字段形态；实际线上为 `_x.ai/session/update`
+        let method = root["method"] as? String ?? ""
+        if !method.isEmpty, !method.contains("session/update") {
+            return nil
+        }
+
+        guard let params = root["params"] as? [String: Any],
+              let update = params["update"] as? [String: Any],
+              let kind = update["sessionUpdate"] as? String,
+              kind == "turn_completed"
+        else { return nil }
+
+        let promptID = nonEmpty(update["prompt_id"] as? String)
+            ?? nonEmpty(update["promptId"] as? String)
+        guard let promptID else { return nil }
+
+        let usage = update["usage"] as? [String: Any] ?? [:]
+        let totalTicks = int64(usage["costUsdTicks"])
+        let timestamp = parseTimestamp(root["timestamp"]) ?? Date()
+
+        var models: [TurnModelUsage] = []
+        if let modelUsage = usage["modelUsage"] as? [String: Any], !modelUsage.isEmpty {
+            for (model, raw) in modelUsage {
+                guard let dict = raw as? [String: Any] else { continue }
+                models.append(TurnModelUsage(
+                    model: model,
+                    inputTokens: int(dict["inputTokens"]),
+                    outputTokens: int(dict["outputTokens"]),
+                    cacheReadTokens: int(dict["cachedReadTokens"]),
+                    reasoningTokens: int(dict["reasoningTokens"]),
+                    costUsdTicks: int64(dict["costUsdTicks"])
+                ))
+            }
+        } else if usage["inputTokens"] != nil || usage["totalTokens"] != nil {
+            // 无 modelUsage 时退回顶层 usage + 缺省模型名
+            models.append(TurnModelUsage(
+                model: "grok-4.5",
+                inputTokens: int(usage["inputTokens"]),
+                outputTokens: int(usage["outputTokens"]),
+                cacheReadTokens: int(usage["cachedReadTokens"]),
+                reasoningTokens: int(usage["reasoningTokens"]),
+                costUsdTicks: totalTicks
+            ))
+        }
+
+        guard !models.isEmpty else { return nil }
+        // 过滤全零用量（取消过早的 turn）
+        models = models.filter {
+            $0.inputTokens + $0.outputTokens + $0.cacheReadTokens + $0.reasoningTokens > 0
+        }
+        guard !models.isEmpty else { return nil }
+
+        return [TurnUsage(
+            promptID: promptID,
+            timestamp: timestamp,
+            models: models,
+            totalCostUsdTicks: totalTicks
+        )]
+    }
+
+    nonisolated private static func resolveCost(
+        ticks: Int64?,
+        model: String,
+        input: Int,
+        output: Int,
+        cacheRead: Int,
+        at date: Date
+    ) -> Decimal? {
+        if let ticks, ticks > 0 {
+            return Decimal(ticks) / ticksPerUSD
+        }
+        return Pricing.cost(
+            app: .grok,
+            model: model,
+            speed: .standard,
+            input: input,
+            output: output,
+            cacheRead: cacheRead,
+            cacheCreation: 0,
+            at: date
+        )
+    }
+
+    // MARK: - Session meta
+
+    private struct SessionMeta {
+        var sessionID: String
+        var cwd: String?
+        var title: String?
+    }
+
+    /// `.../<encoded-cwd>/<session-id>/updates.jsonl` 或 `.../subagents/<id>/updates.jsonl`
+    nonisolated private static func sessionMeta(for updatesURL: URL) -> SessionMeta {
+        let sessionDir = updatesURL.deletingLastPathComponent()
+        var sessionID = sessionDir.lastPathComponent
+        var cwdDir = sessionDir.deletingLastPathComponent()
+
+        if sessionDir.lastPathComponent != "subagents",
+           sessionDir.deletingLastPathComponent().lastPathComponent == "subagents" {
+            // .../<cwd>/<parent>/subagents/<id>/updates.jsonl
+            let parentSession = sessionDir.deletingLastPathComponent().deletingLastPathComponent()
+            sessionID = parentSession.lastPathComponent
+            cwdDir = parentSession.deletingLastPathComponent()
+        } else if sessionDir.lastPathComponent == "subagents" {
+            sessionID = cwdDir.lastPathComponent
+            cwdDir = cwdDir.deletingLastPathComponent()
+        }
+
+        let cwdEncoded = cwdDir.lastPathComponent
+        let cwd = cwdEncoded.removingPercentEncoding ?? cwdEncoded
+
+        var title: String?
+        let summaryURL = sessionDir.appendingPathComponent("summary.json")
+        // subagent 用父会话 summary；若当前目录无 summary 再试父
+        let summaryCandidates = [
+            summaryURL,
+            sessionDir.deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("summary.json")
+        ]
+        for url in summaryCandidates {
+            if let data = try? Data(contentsOf: url),
+               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                title = nonEmpty(root["generated_title"] as? String)
+                    ?? nonEmpty(root["session_summary"] as? String)
+                if title != nil { break }
+            }
+        }
+
+        return SessionMeta(sessionID: sessionID, cwd: cwd, title: title)
+    }
+
+    nonisolated private static func seed(
+        sessionID: String,
+        path: String,
+        title: String?,
+        cwd: String?
+    ) -> ConversationSeed {
+        let project: ConversationProject
+        if let cwd, !cwd.isEmpty {
+            let name = URL(fileURLWithPath: cwd).lastPathComponent
+            project = ConversationProject(
+                key: "cwd:\(cwd)",
+                name: name.isEmpty ? cwd : name,
+                path: cwd,
+                status: .available,
+                source: .cwd
+            )
+        } else {
+            project = .unassigned
+        }
+        return ConversationSeed(
+            key: "grok:\(sessionID)",
+            id: sessionID,
+            app: .grok,
+            title: title,
+            project: project,
+            gitBranch: nil,
+            sourcePath: path,
+            includesSubtasks: path.contains("/subagents/"),
+            cacheCreationAvailable: false
+        )
+    }
+
+    // MARK: - Helpers
+
+    nonisolated private static func parseTimestamp(_ any: Any?) -> Date? {
+        if let n = any as? Double {
+            // Grok updates 用秒级 epoch（约 1.78e9）；兼容毫秒
+            if n > 1e12 { return Date(timeIntervalSince1970: n / 1000) }
+            return Date(timeIntervalSince1970: n)
+        }
+        if let n = any as? Int {
+            let d = Double(n)
+            if d > 1e12 { return Date(timeIntervalSince1970: d / 1000) }
+            return Date(timeIntervalSince1970: d)
+        }
+        if let s = any as? String {
+            return JSONLTimestamp.parse(s)
+        }
+        return nil
+    }
+
+    nonisolated private static func int(_ any: Any?) -> Int {
+        if let i = any as? Int { return max(0, i) }
+        if let d = any as? Double { return max(0, Int(d)) }
+        if let n = any as? NSNumber { return max(0, n.intValue) }
+        if let s = any as? String, let i = Int(s) { return max(0, i) }
+        return 0
+    }
+
+    nonisolated private static func int64(_ any: Any?) -> Int64? {
+        if let i = any as? Int64 { return i }
+        if let i = any as? Int { return Int64(i) }
+        if let d = any as? Double { return Int64(d) }
+        if let n = any as? NSNumber { return n.int64Value }
+        if let s = any as? String, let i = Int64(s) { return i }
+        return nil
+    }
+
+    nonisolated private static func nonEmpty(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+}

--- a/Core/Usage/Pricing.swift
+++ b/Core/Usage/Pricing.swift
@@ -88,17 +88,27 @@ nonisolated enum Pricing {
         "deepseek-reasoner":  .init(input: 0.55,  output: 2.19,  cacheRead: 0.14,     cacheCreation: 0),
         // codex-auto-review 内部 review，官方未公开计费；不入表 → cost=0，token 仍记录
 
-        // —— Grok / xAI 系（USD / 百万 token；Grok 扫描优先用 costUsdTicks，表仅作回退）——
-        // 价位对齐 2026 公开 API 量级；精确计费以 CLI 写入的 ticks 为准。
-        "grok-4.5":        .init(input: 3,    output: 15,  cacheRead: 0.75,  cacheCreation: 0),
-        "grok-4.5-build":  .init(input: 3,    output: 15,  cacheRead: 0.75,  cacheCreation: 0),
-        "grok-build":      .init(input: 3,    output: 15,  cacheRead: 0.75,  cacheCreation: 0),
-        "grok-build-0.1":  .init(input: 2,    output: 10,  cacheRead: 0.40,  cacheCreation: 0),
-        "grok-code-fast":  .init(input: 0.20, output: 1.50, cacheRead: 0.05, cacheCreation: 0),
-        "grok-code-fast-1":.init(input: 0.20, output: 1.50, cacheRead: 0.05, cacheCreation: 0),
-        "grok-4":          .init(input: 3,    output: 15,  cacheRead: 0.75,  cacheCreation: 0),
-        "grok-3":          .init(input: 3,    output: 15,  cacheRead: 0.75,  cacheCreation: 0),
-        "grok-3-mini":     .init(input: 0.30, output: 0.50, cacheRead: 0.07, cacheCreation: 0),
+        // —— Grok / xAI 系（USD / 百万 token）——
+        // 来源：docs.x.ai 公开价（promptTextTokenPrice / 1000 = $/M）。
+        // 本地校验：CLI `costUsdTicks / 1e9` 与「billable_input * in + output * out + cache * cache」完全一致；
+        // reasoningTokens 不单独计费。扫描优先 ticks，本表作无 ticks 时的回退与拆分比例。
+        "grok-4.5":                    .init(input: 20,   output: 60,   cacheRead: 3,    cacheCreation: 0),
+        "grok-4.5-build":              .init(input: 20,   output: 60,   cacheRead: 3,    cacheCreation: 0),
+        "grok-build":                  .init(input: 10,   output: 20,   cacheRead: 2,    cacheCreation: 0),
+        "grok-build-0.1":              .init(input: 10,   output: 20,   cacheRead: 2,    cacheCreation: 0),
+        "grok-4.20":                   .init(input: 12.5, output: 25,   cacheRead: 2,    cacheCreation: 0),
+        "grok-4.20-reasoning":         .init(input: 12.5, output: 25,   cacheRead: 2,    cacheCreation: 0),
+        "grok-4.20-non-reasoning":     .init(input: 12.5, output: 25,   cacheRead: 2,    cacheCreation: 0),
+        "grok-4.20-multi-agent":       .init(input: 12.5, output: 25,   cacheRead: 2,    cacheCreation: 0),
+        "grok-4.3":                    .init(input: 12.5, output: 25,   cacheRead: 2,    cacheCreation: 0),
+        "grok-code-fast":              .init(input: 0.20, output: 1.50, cacheRead: 0.05, cacheCreation: 0),
+        "grok-code-fast-1":            .init(input: 0.20, output: 1.50, cacheRead: 0.05, cacheCreation: 0),
+        // 较旧公开价，仍可能出现在历史 session
+        "grok-4":                      .init(input: 3,    output: 15,   cacheRead: 0.75, cacheCreation: 0),
+        "grok-3":                      .init(input: 3,    output: 15,   cacheRead: 0.75, cacheCreation: 0),
+        "grok-3-mini":                 .init(input: 0.30, output: 0.50, cacheRead: 0.07, cacheCreation: 0),
+        "grok-2":                      .init(input: 2,    output: 10,   cacheRead: 0.50, cacheCreation: 0),
+        "grok-2-1212":                 .init(input: 2,    output: 10,   cacheRead: 0.50, cacheCreation: 0),
     ]
 
     /// Fast / Priority 的显式价格表。远端 LiteLLM / models.dev 目录没有服务档位维度，不能用于覆盖这些价格。
@@ -290,7 +300,39 @@ nonisolated enum Pricing {
                 break
             }
         }
-        return m.lowercased()
+        m = m.lowercased()
+        // Grok CLI 变体：`grok-4.20-0309-reasoning` → 先剥日期段，再映射到价表键
+        // 已由上方日期正则处理一部分；再剥 `-reasoning` / `-non-reasoning` 以外的实验后缀由别名表覆盖。
+        return grokPriceAlias(m)
+    }
+
+    /// 把 CLI / 网关上报的 Grok 模型名映射到价表键。
+    nonisolated private static func grokPriceAlias(_ model: String) -> String {
+        // 精确命中价表则不动
+        if table[model] != nil { return model }
+        // 常见别名
+        let aliases: [String: String] = [
+            "grok-4.5-build-plan": "grok-4.5-build",
+            "grok-build-plan": "grok-build",
+            "grok-code-fast-1-0825": "grok-code-fast-1",
+            "grok-4.20-multi-agent-latest": "grok-4.20-multi-agent",
+            "grok-4.20-reasoning-latest": "grok-4.20-reasoning",
+            "grok-4.20-latest": "grok-4.20",
+        ]
+        if let mapped = aliases[model] { return mapped }
+        // `grok-4.20-0309-reasoning` 已剥日期后可能是 `grok-4.20-reasoning`；
+        // `grok-4.20-beta-reasoning` → 归到 reasoning 价。
+        if model.hasPrefix("grok-4.20") {
+            if model.contains("multi-agent") { return "grok-4.20-multi-agent" }
+            if model.contains("non-reasoning") { return "grok-4.20-non-reasoning" }
+            if model.contains("reasoning") { return "grok-4.20-reasoning" }
+            return "grok-4.20"
+        }
+        if model.hasPrefix("grok-4.5") { return model.contains("build") ? "grok-4.5-build" : "grok-4.5" }
+        if model.hasPrefix("grok-4.3") { return "grok-4.3" }
+        if model.hasPrefix("grok-build") { return "grok-build-0.1" }
+        if model.hasPrefix("grok-code-fast") { return "grok-code-fast-1" }
+        return model
     }
 
     private static let perMillion: Decimal = 1_000_000

--- a/Core/Usage/Pricing.swift
+++ b/Core/Usage/Pricing.swift
@@ -87,6 +87,18 @@ nonisolated enum Pricing {
         "deepseek-chat":      .init(input: 0.27,  output: 1.10,  cacheRead: 0.07,     cacheCreation: 0),
         "deepseek-reasoner":  .init(input: 0.55,  output: 2.19,  cacheRead: 0.14,     cacheCreation: 0),
         // codex-auto-review 内部 review，官方未公开计费；不入表 → cost=0，token 仍记录
+
+        // —— Grok / xAI 系（USD / 百万 token；Grok 扫描优先用 costUsdTicks，表仅作回退）——
+        // 价位对齐 2026 公开 API 量级；精确计费以 CLI 写入的 ticks 为准。
+        "grok-4.5":        .init(input: 3,    output: 15,  cacheRead: 0.75,  cacheCreation: 0),
+        "grok-4.5-build":  .init(input: 3,    output: 15,  cacheRead: 0.75,  cacheCreation: 0),
+        "grok-build":      .init(input: 3,    output: 15,  cacheRead: 0.75,  cacheCreation: 0),
+        "grok-build-0.1":  .init(input: 2,    output: 10,  cacheRead: 0.40,  cacheCreation: 0),
+        "grok-code-fast":  .init(input: 0.20, output: 1.50, cacheRead: 0.05, cacheCreation: 0),
+        "grok-code-fast-1":.init(input: 0.20, output: 1.50, cacheRead: 0.05, cacheCreation: 0),
+        "grok-4":          .init(input: 3,    output: 15,  cacheRead: 0.75,  cacheCreation: 0),
+        "grok-3":          .init(input: 3,    output: 15,  cacheRead: 0.75,  cacheCreation: 0),
+        "grok-3-mini":     .init(input: 0.30, output: 0.50, cacheRead: 0.07, cacheCreation: 0),
     ]
 
     /// Fast / Priority 的显式价格表。远端 LiteLLM / models.dev 目录没有服务档位维度，不能用于覆盖这些价格。
@@ -246,6 +258,9 @@ nonisolated enum Pricing {
                 return codexFastPrices[key]
             case .claude:
                 return claudeFastPrices[key]
+            case .grok:
+                // Grok Build 无独立 Fast 价表；未收录时返回 nil。
+                return nil
             }
         }
     }
@@ -259,6 +274,9 @@ nonisolated enum Pricing {
         }
         if m.hasPrefix("deepseek/") {
             m.removeFirst("deepseek/".count)
+        }
+        if m.hasPrefix("xai/") {
+            m.removeFirst("xai/".count)
         }
         // Vertex 风格：`name@YYYYMMDD`
         if let at = m.firstIndex(of: "@") {
@@ -369,6 +387,7 @@ nonisolated enum Pricing {
             switch app {
             case .codex: return codexFastMultipliers[key]
             case .claude: return claudeFastMultipliers[key]
+            case .grok: return nil
             }
         }
     }

--- a/Core/Usage/UsageModels.swift
+++ b/Core/Usage/UsageModels.swift
@@ -3,6 +3,7 @@ import Foundation
 nonisolated enum UsageApp: String, Sendable, Codable, Hashable, CaseIterable {
     case codex
     case claude
+    case grok
 }
 
 /// 单次请求实际使用的服务速度档位。`unknown` 只用于日志缺失或出现未来新值时，不能静默按 Standard 计价。

--- a/Core/Usage/UsageService.swift
+++ b/Core/Usage/UsageService.swift
@@ -132,21 +132,27 @@ final class UsageService {
     private func runScan(prev: ScanState) async -> Bool {
         let started = Date()
         let prevSeen = prev.claudeSeenMessageIds
+        let prevGrokSeen = prev.grokSeenPromptIds
         async let claudeTask = Task.detached(priority: .utility) {
             ClaudeJSONLScanner.scan(previous: prev.claude, seenMessageIds: prevSeen)
         }.value
         async let codexTask = Task.detached(priority: .utility) {
             CodexJSONLScanner.scan(previous: prev.codex)
         }.value
+        async let grokTask = Task.detached(priority: .utility) {
+            GrokJSONLScanner.scan(previous: prev.grok, seenPromptIds: prevGrokSeen)
+        }.value
 
         let claude = await claudeTask
         let codex = await codexTask
+        let grok = await grokTask
 
         aggregator.ingest(claude.entries)
         aggregator.ingest(codex.entries)
+        aggregator.ingest(grok.entries)
         let conversationChanged = conversationAggregator.ingest(
-            entries: claude.entries + codex.entries,
-            seeds: claude.conversationSeeds + codex.conversationSeeds
+            entries: claude.entries + codex.entries + grok.entries,
+            seeds: claude.conversationSeeds + codex.conversationSeeds + grok.conversationSeeds
         )
 
         // 个人历史用量一次性补录：缓存失效路径会清空聚合器，若只在 bootstrap 合并，
@@ -158,7 +164,7 @@ final class UsageService {
         // 没有真实用量或档案变化时沿用现有代次，只提交轻量 watermark。
         let buckets = aggregator.snapshot()
         let fingerprint = Pricing.fingerprint(knownModels: Set(buckets.map { $0.model }))
-        let hasNewEntries = !claude.entries.isEmpty || !codex.entries.isEmpty
+        let hasNewEntries = !claude.entries.isEmpty || !codex.entries.isEmpty || !grok.entries.isEmpty
         let shouldWriteRollups = loadedRollupGeneration == nil || hasNewEntries || conversationChanged
         let generationID = shouldWriteRollups ? UUID().uuidString : loadedRollupGeneration!
         let newScanState = ScanState(
@@ -166,7 +172,9 @@ final class UsageService {
             pricingFingerprint: fingerprint,
             claude: claude.newState,
             codex: codex.newState,
-            claudeSeenMessageIds: claude.newSeenIds
+            grok: grok.newState,
+            claudeSeenMessageIds: claude.newSeenIds,
+            grokSeenPromptIds: grok.newSeenIds
         )
         let shouldWriteScanState = newScanState != prev
 
@@ -230,7 +238,7 @@ final class UsageService {
         publishTotals()
 
         let elapsed = String(format: "%.2fs", Date().timeIntervalSince(started))
-        print("[UsageScan 用量扫描] claude files=\(claude.filesScanned) lines=\(claude.linesParsed) new=\(claude.entries.count); codex files=\(codex.filesScanned) lines=\(codex.linesParsed) new=\(codex.entries.count); elapsed=\(elapsed)")
+        print("[UsageScan 用量扫描] claude files=\(claude.filesScanned) lines=\(claude.linesParsed) new=\(claude.entries.count); codex files=\(codex.filesScanned) lines=\(codex.linesParsed) new=\(codex.entries.count); grok files=\(grok.filesScanned) lines=\(grok.linesParsed) new=\(grok.entries.count); elapsed=\(elapsed)")
         return true
     }
 
@@ -238,5 +246,6 @@ final class UsageService {
         guard let appState else { return }
         appState.codexTodayCost = aggregator.todayCost(for: .codex)
         appState.claudeTodayCost = aggregator.todayCost(for: .claude)
+        appState.grokTodayCost = aggregator.todayCost(for: .grok)
     }
 }

--- a/Main/ConversationStatsView.swift
+++ b/Main/ConversationStatsView.swift
@@ -246,6 +246,7 @@ struct ConversationStatsView: View {
         case .all: return nil
         case .codex: return .codex
         case .claude: return .claude
+        case .grok: return .grok
         }
     }
 
@@ -329,13 +330,29 @@ private struct ConversationScanStatus: View {
     }
 }
 
+private func usageAccent(_ app: UsageApp) -> Color {
+    switch app {
+    case .codex: return .codexAccent
+    case .claude: return .claudeAccent
+    case .grok: return .grokAccent
+    }
+}
+
+private func usageTitle(_ app: UsageApp) -> String {
+    switch app {
+    case .codex: return "Codex"
+    case .claude: return "Claude Code"
+    case .grok: return "Grok"
+    }
+}
+
 private struct ConversationListRow: View {
     let summary: ConversationSummary
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 7) {
-                ServiceMark(color: summary.info.app == .codex ? .codexAccent : .claudeAccent, size: 8)
+                ServiceMark(color: usageAccent(summary.info.app), size: 8)
                 Text(summary.info.title ?? tr("Untitled", "（无标题）"))
                     .font(.system(size: 12.5, weight: .medium))
                     .lineLimit(1)
@@ -406,8 +423,8 @@ private struct ConversationDetailView: View {
     private var header: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
-                ServiceMark(color: detail.info.app == .codex ? .codexAccent : .claudeAccent, size: 9)
-                Text(detail.info.app == .codex ? "Codex" : "Claude Code")
+                ServiceMark(color: usageAccent(detail.info.app), size: 9)
+                Text(usageTitle(detail.info.app))
                     .font(.system(size: 11.5, weight: .semibold))
                 Text(tr("All time", "全部时间"))
                     .font(.system(size: 10, weight: .medium))

--- a/Main/DesignSystem.swift
+++ b/Main/DesignSystem.swift
@@ -13,6 +13,7 @@ extension QuotaApp {
         case .codex: .codexAccent
         case .claude: .claudeAccent
         case .antigravity: .antigravityAccent
+        case .grok: .grokAccent
         }
     }
 }

--- a/Main/StatsView.swift
+++ b/Main/StatsView.swift
@@ -109,12 +109,14 @@ enum StatsServiceFilter: Hashable, CaseIterable {
     case all
     case codex
     case claude
+    case grok
 
     var englishLabel: String {
         switch self {
         case .all: return "All"
         case .codex: return "Codex"
         case .claude: return "Claude Code"
+        case .grok: return "Grok"
         }
     }
 
@@ -123,6 +125,7 @@ enum StatsServiceFilter: Hashable, CaseIterable {
         case .all: return "全部"
         case .codex: return "Codex"
         case .claude: return "Claude Code"
+        case .grok: return "Grok"
         }
     }
 
@@ -131,6 +134,7 @@ enum StatsServiceFilter: Hashable, CaseIterable {
         case .all: return nil
         case .codex: return .codexAccent
         case .claude: return .claudeAccent
+        case .grok: return .grokAccent
         }
     }
 }
@@ -400,28 +404,47 @@ struct StatsView: View {
             KPICard(
                 english: "Codex",
                 chinese: "Codex",
-                value: serviceFilter == .claude
+                value: serviceFilter != .all && serviceFilter != .codex
                     ? "—"
                     : StatsFormatter.tierCost(
                         currentTotals(.codex).costUSD,
                         hasUnpricedUsage: currentTotals(.codex).hasUnpricedUsage
                     ),
-                delta: serviceFilter == .claude ? nil : costDelta(current: currentTotals(.codex), previous: previousTotals(.codex)),
+                delta: serviceFilter != .all && serviceFilter != .codex
+                    ? nil
+                    : costDelta(current: currentTotals(.codex), previous: previousTotals(.codex)),
                 tint: .codexAccent,
-                dimmed: serviceFilter == .claude
+                dimmed: serviceFilter != .all && serviceFilter != .codex
             )
             KPICard(
                 english: "Claude Code",
                 chinese: "Claude Code",
-                value: serviceFilter == .codex
+                value: serviceFilter != .all && serviceFilter != .claude
                     ? "—"
                     : StatsFormatter.tierCost(
                         currentTotals(.claude).costUSD,
                         hasUnpricedUsage: currentTotals(.claude).hasUnpricedUsage
                     ),
-                delta: serviceFilter == .codex ? nil : costDelta(current: currentTotals(.claude), previous: previousTotals(.claude)),
+                delta: serviceFilter != .all && serviceFilter != .claude
+                    ? nil
+                    : costDelta(current: currentTotals(.claude), previous: previousTotals(.claude)),
                 tint: .claudeAccent,
-                dimmed: serviceFilter == .codex
+                dimmed: serviceFilter != .all && serviceFilter != .claude
+            )
+            KPICard(
+                english: "Grok",
+                chinese: "Grok",
+                value: serviceFilter != .all && serviceFilter != .grok
+                    ? "—"
+                    : StatsFormatter.tierCost(
+                        currentTotals(.grok).costUSD,
+                        hasUnpricedUsage: currentTotals(.grok).hasUnpricedUsage
+                    ),
+                delta: serviceFilter != .all && serviceFilter != .grok
+                    ? nil
+                    : costDelta(current: currentTotals(.grok), previous: previousTotals(.grok)),
+                tint: .grokAccent,
+                dimmed: serviceFilter != .all && serviceFilter != .grok
             )
         }
     }
@@ -453,6 +476,7 @@ struct StatsView: View {
                 }
                 LegendChip(color: .codexAccent, label: "Codex")
                 LegendChip(color: .claudeAccent, label: "Claude Code")
+                LegendChip(color: .grokAccent, label: "Grok")
             }
         )) {
             VStack(spacing: 6) {
@@ -482,6 +506,16 @@ struct StatsView: View {
                                 stacking: .standard
                             )
                             .foregroundStyle(Color.claudeAccent)
+                            .opacity(barOpacity(for: sample))
+                            .cornerRadius(2)
+
+                            BarMark(
+                                x: .value("Day", sample.day, unit: .day),
+                                y: .value("Cost", sample.grokCost.doubleValue),
+                                width: .fixed(dailyBarWidth),
+                                stacking: .standard
+                            )
+                            .foregroundStyle(Color.grokAccent)
                             .opacity(barOpacity(for: sample))
                             .cornerRadius(2)
                         }
@@ -543,6 +577,16 @@ struct StatsView: View {
                     speed: currentSpeedBreakdown(.claude)
                 )
                 .frame(maxWidth: .infinity, alignment: .leading)
+                ByServiceRow(
+                    title: "Grok",
+                    subtitle: "xAI",
+                    tint: .grokAccent,
+                    value: currentTotals(.grok).costUSD,
+                    totalValue: currentTotalsAll.costUSD,
+                    totals: currentTotals(.grok),
+                    speed: currentSpeedBreakdown(.grok)
+                )
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
     }
@@ -552,14 +596,20 @@ struct StatsView: View {
     private var byModelPanel: some View {
         Panel(title: "By model", chinese: "按模型") {
             VStack(alignment: .leading, spacing: 10) {
-                if serviceFilter != .claude {
+                if serviceFilter == .all || serviceFilter == .codex {
                     modelGroup(title: "Codex", tint: .codexAccent, rows: modelRows(for: .codex))
                 }
-                if serviceFilter != .codex && serviceFilter != .claude {
+                if serviceFilter == .all {
                     Divider()
                 }
-                if serviceFilter != .codex {
+                if serviceFilter == .all || serviceFilter == .claude {
                     modelGroup(title: "Claude Code", tint: .claudeAccent, rows: modelRows(for: .claude))
+                }
+                if serviceFilter == .all {
+                    Divider()
+                }
+                if serviceFilter == .all || serviceFilter == .grok {
+                    modelGroup(title: "Grok", tint: .grokAccent, rows: modelRows(for: .grok))
                 }
             }
         }
@@ -746,6 +796,8 @@ struct StatsView: View {
             return buckets.filter { $0.app == .codex }
         case .claude:
             return buckets.filter { $0.app == .claude }
+        case .grok:
+            return buckets.filter { $0.app == .grok }
         }
     }
 
@@ -795,8 +847,13 @@ struct StatsView: View {
             .filter { $0.day >= bounds.from && $0.day < bounds.to }
         var t = UsageTotals.zero
         for b in buckets {
-            if serviceFilter == .codex && b.app != .codex { continue }
-            if serviceFilter == .claude && b.app != .claude { continue }
+            switch serviceFilter {
+            case .all: break
+            case .codex where b.app != .codex: continue
+            case .claude where b.app != .claude: continue
+            case .grok where b.app != .grok: continue
+            default: break
+            }
             t.add(b)
         }
         return t
@@ -823,18 +880,24 @@ struct StatsView: View {
 
     private var dailySamples: [DailySample] {
         let (from, to) = chartBounds
-        var byDay: [Date: (codex: UsageTotals, claude: UsageTotals)] = [:]
+        var byDay: [Date: (codex: UsageTotals, claude: UsageTotals, grok: UsageTotals)] = [:]
         for b in filteredBuckets(from: from, to: to) {
-            var pair = byDay[b.day] ?? (.zero, .zero)
+            var triple = byDay[b.day] ?? (.zero, .zero, .zero)
             switch b.app {
-            case .codex: pair.codex.add(b)
-            case .claude: pair.claude.add(b)
+            case .codex: triple.codex.add(b)
+            case .claude: triple.claude.add(b)
+            case .grok: triple.grok.add(b)
             }
-            byDay[b.day] = pair
+            byDay[b.day] = triple
         }
         return byDay
             .map {
-                DailySample(day: $0.key, codex: $0.value.codex, claude: $0.value.claude)
+                DailySample(
+                    day: $0.key,
+                    codex: $0.value.codex,
+                    claude: $0.value.claude,
+                    grok: $0.value.grok
+                )
             }
             .sorted { $0.day < $1.day }
     }
@@ -965,6 +1028,10 @@ private struct DailyTooltip: View {
             serviceRow(color: .claudeAccent, label: "Claude Code", value: StatsFormatter.tierCost(
                 sample.claudeCost,
                 hasUnpricedUsage: sample.claude.hasUnpricedUsage
+            ))
+            serviceRow(color: .grokAccent, label: "Grok", value: StatsFormatter.tierCost(
+                sample.grokCost,
+                hasUnpricedUsage: sample.grok.hasUnpricedUsage
             ))
 
             Divider()
@@ -1576,21 +1643,23 @@ private struct DailySample: Identifiable {
     let day: Date
     let codex: UsageTotals
     let claude: UsageTotals
+    let grok: UsageTotals
 
     var codexCost: Decimal { codex.costUSD }
     var claudeCost: Decimal { claude.costUSD }
-    var totalCost: Decimal { codexCost + claudeCost }
+    var grokCost: Decimal { grok.costUSD }
+    var totalCost: Decimal { codexCost + claudeCost + grokCost }
     var totalTokens: Int { totalUsage.totalTokens }
 
-    /// codex + claude 合并后的口径,供每日悬浮明细展示 token 拆分 + 命中率。
+    /// 各服务合并后的口径,供每日悬浮明细展示 token 拆分 + 命中率。
     var totalUsage: UsageTotals {
         var t = UsageTotals.zero
-        t.inputTokens = codex.inputTokens + claude.inputTokens
-        t.outputTokens = codex.outputTokens + claude.outputTokens
-        t.cacheReadTokens = codex.cacheReadTokens + claude.cacheReadTokens
-        t.cacheCreationTokens = codex.cacheCreationTokens + claude.cacheCreationTokens
+        t.inputTokens = codex.inputTokens + claude.inputTokens + grok.inputTokens
+        t.outputTokens = codex.outputTokens + claude.outputTokens + grok.outputTokens
+        t.cacheReadTokens = codex.cacheReadTokens + claude.cacheReadTokens + grok.cacheReadTokens
+        t.cacheCreationTokens = codex.cacheCreationTokens + claude.cacheCreationTokens + grok.cacheCreationTokens
         t.costUSD = totalCost
-        t.hasUnpricedUsage = codex.hasUnpricedUsage || claude.hasUnpricedUsage
+        t.hasUnpricedUsage = codex.hasUnpricedUsage || claude.hasUnpricedUsage || grok.hasUnpricedUsage
         return t
     }
 }

--- a/Main/StatsView.swift
+++ b/Main/StatsView.swift
@@ -636,7 +636,7 @@ struct StatsView: View {
     private var timelineSections: [QuotaTimelineSection] {
         var sections: [QuotaTimelineSection] = []
 
-        if serviceFilter != .claude {
+        if serviceFilter == .all || serviceFilter == .codex {
             let key = QuotaHistoryAccountKey.codexPrimary(accountId: appState.codexAccount?.accountId)
             var addedPrimaryCodex = false
             if shouldShowTimelineSection(key: key, snapshot: appState.codexQuota, accountExists: appState.codexAccount != nil) {
@@ -664,7 +664,7 @@ struct StatsView: View {
             }
         }
 
-        if serviceFilter != .codex {
+        if serviceFilter == .all || serviceFilter == .claude {
             let key = QuotaHistoryAccountKey.claudePrimary()
             if shouldShowTimelineSection(key: key, snapshot: appState.claudeQuota, accountExists: appState.claudeAccount != nil) {
                 sections.append(timelineSection(
@@ -673,6 +673,19 @@ struct StatsView: View {
                     tint: .claudeAccent,
                     snapshot: appState.claudeQuota,
                     isLoading: appState.refreshState(for: .claude).inFlight
+                ))
+            }
+        }
+
+        if serviceFilter == .all || serviceFilter == .grok {
+            let key = QuotaHistoryAccountKey.grokPrimary(userId: appState.grokAccount?.userId)
+            if shouldShowTimelineSection(key: key, snapshot: appState.grokQuota, accountExists: appState.grokAccount != nil) {
+                sections.append(timelineSection(
+                    key: key,
+                    title: "Grok",
+                    tint: .grokAccent,
+                    snapshot: appState.grokQuota,
+                    isLoading: appState.refreshState(for: .grok).inFlight
                 ))
             }
         }

--- a/MenuBar/PopoverRootView.swift
+++ b/MenuBar/PopoverRootView.swift
@@ -186,7 +186,8 @@ struct PopoverRootView: View {
             fallback = "Google"
         case .grok:
             email = appState.grokAccount?.email
-            plan = appState.grokAccount?.planType?.capitalized
+            // planType 已是展示名（SuperGrok 等），不再二次 capitalized 破坏大小写
+            plan = appState.grokAccount?.planType
             fallback = "xAI"
         }
         if !privacy, let email, !email.isEmpty { parts.append(email) }

--- a/MenuBar/PopoverRootView.swift
+++ b/MenuBar/PopoverRootView.swift
@@ -221,7 +221,8 @@ struct PopoverRootView: View {
         switch app {
         case .codex: usageApp = .codex
         case .claude: usageApp = .claude
-        case .antigravity, .grok: return nil
+        case .grok: usageApp = .grok
+        case .antigravity: return nil
         }
         let (from, to) = Self.weekBounds()
         let totals = appState.usageService.aggregator.totals(app: usageApp, from: from, to: to)
@@ -232,7 +233,8 @@ struct PopoverRootView: View {
         switch app {
         case .codex: appState.codexTodayCost
         case .claude: appState.claudeTodayCost
-        case .antigravity, .grok: nil
+        case .grok: appState.grokTodayCost
+        case .antigravity: nil
         }
     }
 

--- a/MenuBar/PopoverRootView.swift
+++ b/MenuBar/PopoverRootView.swift
@@ -184,6 +184,10 @@ struct PopoverRootView: View {
             email = appState.antigravityAccount?.email
             plan = appState.antigravityAccount?.planType
             fallback = "Google"
+        case .grok:
+            email = appState.grokAccount?.email
+            plan = appState.grokAccount?.planType?.capitalized
+            fallback = "xAI"
         }
         if !privacy, let email, !email.isEmpty { parts.append(email) }
         if let plan, !plan.isEmpty { parts.append(plan) }
@@ -217,7 +221,7 @@ struct PopoverRootView: View {
         switch app {
         case .codex: usageApp = .codex
         case .claude: usageApp = .claude
-        case .antigravity: return nil
+        case .antigravity, .grok: return nil
         }
         let (from, to) = Self.weekBounds()
         let totals = appState.usageService.aggregator.totals(app: usageApp, from: from, to: to)
@@ -228,7 +232,7 @@ struct PopoverRootView: View {
         switch app {
         case .codex: appState.codexTodayCost
         case .claude: appState.claudeTodayCost
-        case .antigravity: nil
+        case .antigravity, .grok: nil
         }
     }
 
@@ -237,7 +241,7 @@ struct PopoverRootView: View {
         return switch app {
         case .codex: appState.codexServiceStatus
         case .claude: appState.claudeServiceStatus
-        case .antigravity: nil as ServiceStatus?
+        case .antigravity, .grok: nil as ServiceStatus?
         }
     }
 

--- a/Onboarding/OnboardingView.swift
+++ b/Onboarding/OnboardingView.swift
@@ -189,6 +189,17 @@ private struct DetectAccountsStep: View {
                     fallback: "A",
                     isDetected: antigravityDetected
                 )
+                DetectedAccountRow(
+                    title: "Grok",
+                    subtitle: "xAI",
+                    plan: appState.grokAccount?.planType,
+                    email: appState.grokAccount?.email,
+                    source: "~/.grok/auth.json",
+                    tint: .grokAccent,
+                    logoName: "grok",
+                    fallback: "G",
+                    isDetected: appState.grokAccount != nil
+                )
             }
             .padding(.top, 18)
 
@@ -227,7 +238,10 @@ private struct DetectAccountsStep: View {
     }
 
     private var anyDetected: Bool {
-        appState.codexAccount != nil || appState.claudeAccount != nil || antigravityDetected
+        appState.codexAccount != nil
+            || appState.claudeAccount != nil
+            || antigravityDetected
+            || appState.grokAccount != nil
     }
 }
 

--- a/Onboarding/OnboardingView.swift
+++ b/Onboarding/OnboardingView.swift
@@ -23,7 +23,8 @@ struct OnboardingView: View {
                 progressDots.padding(.bottom, 16)
             }
         }
-        .frame(width: 620, height: 520)
+        // 检测页现有 4 个 Provider 行，略增高避免底部按钮被挤。
+        .frame(width: 620, height: 560)
         .background(.regularMaterial)
         .animation(.easeInOut(duration: 0.25), value: step)
     }
@@ -81,14 +82,14 @@ private struct WelcomeStep: View {
                 .kerning(-0.4)
 
             Text(tr(
-                "Track Codex, Claude Code, and Antigravity quota right from your menu bar. We'll detect local providers automatically.",
-                "在菜单栏即时查看 Codex、Claude Code 与 Antigravity 的额度,我们将自动检测本机服务。"
+                "Track Codex, Claude Code, Antigravity, and Grok quota right from your menu bar. We'll detect local providers automatically.",
+                "在菜单栏即时查看 Codex、Claude Code、Antigravity 与 Grok 的额度,我们将自动检测本机服务。"
             ))
                 .font(.system(size: 13))
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .lineSpacing(2)
-                .frame(maxWidth: 380)
+                .frame(maxWidth: 400)
                 .padding(.top, 14)
 
             VStack(spacing: 8) {
@@ -351,19 +352,36 @@ private struct ConfigureStep: View {
                              chineseTitle: "菜单栏",
                              subtitle: "Show enabled providers next to the menu bar icon.",
                              chineseSubtitle: "在菜单栏图标旁显示百分比") {
-                    HStack(spacing: 12) {
-                        Toggle("Codex", isOn: Binding(get: { settings.menuBarShowCodex }, set: { settings.menuBarShowCodex = $0 }))
+                    // 两行排布，避免 4 个 Provider 挤在一行。
+                    VStack(alignment: .trailing, spacing: 8) {
+                        HStack(spacing: 12) {
+                            Toggle("Codex", isOn: Binding(
+                                get: { settings.menuBarShowCodex },
+                                set: { settings.menuBarShowCodex = $0 }
+                            ))
                             .toggleStyle(.switch)
                             .tint(.green)
-                        Toggle("Claude Code", isOn: Binding(get: { settings.menuBarShowClaude }, set: { settings.menuBarShowClaude = $0 }))
+                            Toggle("Claude Code", isOn: Binding(
+                                get: { settings.menuBarShowClaude },
+                                set: { settings.menuBarShowClaude = $0 }
+                            ))
                             .toggleStyle(.switch)
                             .tint(.green)
-                        Toggle("Antigravity", isOn: Binding(
-                            get: { settings.menuBarShowAntigravity },
-                            set: { settings.menuBarShowAntigravity = $0 }
-                        ))
-                        .toggleStyle(.switch)
-                        .tint(.green)
+                        }
+                        HStack(spacing: 12) {
+                            Toggle("Antigravity", isOn: Binding(
+                                get: { settings.menuBarShowAntigravity },
+                                set: { settings.menuBarShowAntigravity = $0 }
+                            ))
+                            .toggleStyle(.switch)
+                            .tint(.green)
+                            Toggle("Grok", isOn: Binding(
+                                get: { settings.menuBarShowGrok },
+                                set: { settings.menuBarShowGrok = $0 }
+                            ))
+                            .toggleStyle(.switch)
+                            .tint(.green)
+                        }
                     }
                 }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cc-bar
 
-> macOS 菜单栏小工具 —— 一眼看清 Codex、Claude Code 与 Antigravity 的剩余额度。
+> macOS 菜单栏小工具 —— 一眼看清 Codex、Claude Code、Antigravity 与 Grok 的剩余额度。
 
 <p>
   <img alt="platform" src="https://img.shields.io/badge/macOS-14+-blue.svg">
@@ -14,10 +14,10 @@
 
 ## 功能
 
-- **额度显示** —— Codex、Claude Code 与 Antigravity 的 5 小时 / 周窗口剩余额度,实时同步
+- **额度显示** —— Codex、Claude Code、Antigravity 与 Grok 的剩余额度,实时同步
 - **菜单栏 + 悬浮窗** —— 状态栏图标显示剩余百分比;可选桌面悬浮 HUD,可拖动、边缘吸附、置顶不抢焦
 - **多 Codex 账号** —— 支持导入多个 Codex 账号,主副账号在 Popover 同屏展示;设置页可查看每个账号的额外重置次数与到期时间
-- **Token 与费用统计** —— 按今天 / 昨天 / 本周 / 本月 / 本年 / 7 天 / 30 天 / 全部 / 自定义切换;KPI、堆叠柱状图、按服务占比、按模型明细
+- **Token 与费用统计** —— 按今天 / 昨天 / 本周 / 本月 / 本年 / 7 天 / 30 天 / 全部 / 自定义切换;KPI、堆叠柱状图、按服务占比、按模型明细（Codex / Claude）
 - **丰富的设置** —— 账号开关、菜单栏显示项、悬浮窗、刷新间隔、重置时间显示、中英双语、开机自动启动
 
 <p align="center">
@@ -37,7 +37,7 @@
 
 ## 安装
 
-要求 macOS 14 Sonoma 或更新版本。Codex / Claude Code 需已通过终端登录；Antigravity 需安装官方 App 或 IDE，并在运行时提供本地额度服务。
+要求 macOS 14 Sonoma 或更新版本。Codex / Claude Code / Grok 需已通过终端登录；Antigravity 需安装官方 App 或 IDE，并在运行时提供本地额度服务。
 
 1. 到 [Releases](https://github.com/nanvon/cc-bar/releases) 下载最新 `CCBar.app.zip`,解压后把 `CCBar.app` 拖入 `/Applications`。
 
@@ -54,7 +54,7 @@
 
 ## 关于本项目与安全性
 
-cc-bar 是 vibe coding 出来满足个人需求的小工具,并非商业化产品。为了显示额度,它需要读取本地的登录凭据:Codex 的 `~/.codex/auth.json`、Claude Code 的 `~/.claude/.credentials.json` 以及 macOS Keychain。Antigravity 只连接官方进程在 `127.0.0.1` 暴露的本地 Language Server,不保存 Google OAuth 凭据,也不会启动 CLI 或发送模型请求。
+cc-bar 是 vibe coding 出来满足个人需求的小工具,并非商业化产品。为了显示额度,它需要读取本地的登录凭据:Codex 的 `~/.codex/auth.json`、Claude Code 的 `~/.claude/.credentials.json` 与 macOS Keychain、Grok Build 的 `~/.grok/auth.json`。Antigravity 只连接官方进程在 `127.0.0.1` 暴露的本地 Language Server,不保存 Google OAuth 凭据,也不会启动 CLI 或发送模型请求。Grok 额度来自 xAI 统一计费接口（与 `grok` CLI 相同），token 过期时会用 refresh_token 续期并写回 `auth.json`。
 
 发布的 `CCBar.app` 未做 Apple 付费公证(详见上方「安装」)。如果你介意安全性,完全可以**自己用 AI 审阅本仓库代码**,确认无误后**按下方教程自行构建**,不依赖我发布的二进制包。
 

--- a/Resources/Assets.xcassets/GrokAccent.colorset/Contents.json
+++ b/Resources/Assets.xcassets/GrokAccent.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x5C",
+          "red" : "0x6B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x7C",
+          "red" : "0x8B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Resources/Logos/grok.svg
+++ b/Resources/Logos/grok.svg
@@ -1,0 +1,5 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Stylized G mark for Grok / xAI menu-bar tile (white on accent) -->
+  <path d="M50 12C29.014 12 12 29.014 12 50s17.014 38 38 38c12.426 0 23.55-5.966 30.5-15.2l-11.2-7.4C64.7 72.2 57.8 76 50 76c-14.36 0-26-11.64-26-26s11.64-26 26-26c9.3 0 17.4 4.9 21.9 12.2H50v14h36.5C84.2 28.8 68.7 12 50 12z" fill="white"/>
+  <circle cx="70" cy="50" r="6" fill="white"/>
+</svg>

--- a/Resources/Logos/grok.svg
+++ b/Resources/Logos/grok.svg
@@ -1,6 +1,10 @@
-<svg width="100" height="100" viewBox="0 0 466.04 516.93" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- Official xAI monogram (white on accent tile), adapted from public XAI logo geometry -->
-  <g fill="white">
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!--
+    Official xAI monogram, optically sized for menu bar / tiles.
+    Source geometry is tall (~466×517); we center it in a 100×100 frame with
+    ~20% padding so it matches Codex/Claude glyph weight at 18pt.
+  -->
+  <g fill="white" transform="translate(20.5 16.5) scale(0.127)">
     <polygon points="0.12 182.71 234.14 516.92 338.15 516.92 104.13 182.71 0.12 182.71"/>
     <polygon points="0 516.92 104.08 516.92 156.08 442.67 104.04 368.34 0 516.92"/>
     <polygon points="466.04 0 361.96 0 182.1 256.86 234.15 331.18 466.04 0"/>

--- a/Resources/Logos/grok.svg
+++ b/Resources/Logos/grok.svg
@@ -1,5 +1,9 @@
-<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- Stylized G mark for Grok / xAI menu-bar tile (white on accent) -->
-  <path d="M50 12C29.014 12 12 29.014 12 50s17.014 38 38 38c12.426 0 23.55-5.966 30.5-15.2l-11.2-7.4C64.7 72.2 57.8 76 50 76c-14.36 0-26-11.64-26-26s11.64-26 26-26c9.3 0 17.4 4.9 21.9 12.2H50v14h36.5C84.2 28.8 68.7 12 50 12z" fill="white"/>
-  <circle cx="70" cy="50" r="6" fill="white"/>
+<svg width="100" height="100" viewBox="0 0 466.04 516.93" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Official xAI monogram (white on accent tile), adapted from public XAI logo geometry -->
+  <g fill="white">
+    <polygon points="0.12 182.71 234.14 516.92 338.15 516.92 104.13 182.71 0.12 182.71"/>
+    <polygon points="0 516.92 104.08 516.92 156.08 442.67 104.04 368.34 0 516.92"/>
+    <polygon points="466.04 0 361.96 0 182.1 256.86 234.15 331.18 466.04 0"/>
+    <polygon points="380.78 516.92 466.04 516.92 466.04 37.16 380.78 158.92 380.78 516.92"/>
+  </g>
 </svg>

--- a/Settings/SettingsRootView.swift
+++ b/Settings/SettingsRootView.swift
@@ -98,6 +98,18 @@ struct SettingsRootView: View {
                         set: { settings.showAntigravity = $0 }
                     )
                 )
+                AccountRow(
+                    title: "Grok",
+                    subtitle: "xAI",
+                    tint: .grokAccent,
+                    logoName: "grok",
+                    fallback: "G",
+                    email: appState.grokAccount?.email,
+                    plan: appState.grokAccount?.planType,
+                    availability: appState.grokAccount == nil ? .notDetected : .connected,
+                    canToggle: appState.grokAccount != nil,
+                    isOn: Binding(get: { settings.showGrok }, set: { settings.showGrok = $0 })
+                )
             }
 
             // 其他 Codex 账号（手动导入）

--- a/ccbar.xcodeproj/project.pbxproj
+++ b/ccbar.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		49C1B1A1000000000001AABB /* GrokTokenRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C1B1A1000000000001AAAA /* GrokTokenRefresher.swift */; };
 		49C1B1A2000000000001AABB /* GrokQuotaClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C1B1A2000000000001AAAA /* GrokQuotaClient.swift */; };
 		49C1B1A3000000000001AABB /* grok.svg in Resources */ = {isa = PBXBuildFile; fileRef = 49C1B1A3000000000001AAAA /* grok.svg */; };
+		49C1B1A4000000000001AABB /* GrokJSONLScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C1B1A4000000000001AAAA /* GrokJSONLScanner.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -158,6 +159,7 @@
 		49C1B1A1000000000001AAAA /* GrokTokenRefresher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrokTokenRefresher.swift; sourceTree = "<group>"; };
 		49C1B1A2000000000001AAAA /* GrokQuotaClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrokQuotaClient.swift; sourceTree = "<group>"; };
 		49C1B1A3000000000001AAAA /* grok.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = grok.svg; sourceTree = "<group>"; };
+		49C1B1A4000000000001AAAA /* GrokJSONLScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrokJSONLScanner.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -332,6 +334,7 @@
 				49C1B151000000000001AAAA /* Pricing.swift */,
 				49C1B152000000000001AAAA /* JSONLLineReader.swift */,
 				49C1B153000000000001AAAA /* ClaudeJSONLScanner.swift */,
+				49C1B1A4000000000001AAAA /* GrokJSONLScanner.swift */,
 				49C1B154000000000001AAAA /* CodexJSONLScanner.swift */,
 				49C1B155000000000001AAAA /* UsageAggregator.swift */,
 				49C1B156000000000001AAAA /* UsageService.swift */,
@@ -579,6 +582,7 @@
 				49C1B151000000000001AABB /* Pricing.swift in Sources */,
 				49C1B152000000000001AABB /* JSONLLineReader.swift in Sources */,
 				49C1B153000000000001AABB /* ClaudeJSONLScanner.swift in Sources */,
+				49C1B1A4000000000001AABB /* GrokJSONLScanner.swift in Sources */,
 				49C1B154000000000001AABB /* CodexJSONLScanner.swift in Sources */,
 				49C1B155000000000001AABB /* UsageAggregator.swift in Sources */,
 				49C1B156000000000001AABB /* UsageService.swift in Sources */,

--- a/ccbar.xcodeproj/project.pbxproj
+++ b/ccbar.xcodeproj/project.pbxproj
@@ -69,6 +69,10 @@
 		49C1B300000000000001AABB /* QuotaParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C1B300000000000001AAAA /* QuotaParsingTests.swift */; };
 		49C1B3F3000000000001AABB /* codex-fast-scan.jsonl in Resources */ = {isa = PBXBuildFile; fileRef = 49C1B3F0000000000001AAAA /* codex-fast-scan.jsonl */; };
 		49C1B3F4000000000001AABB /* claude-fast-scan.jsonl in Resources */ = {isa = PBXBuildFile; fileRef = 49C1B3F1000000000001AAAA /* claude-fast-scan.jsonl */; };
+49C1B1A0000000000001AABB /* GrokAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C1B1A0000000000001AAAA /* GrokAuth.swift */; };
+		49C1B1A1000000000001AABB /* GrokTokenRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C1B1A1000000000001AAAA /* GrokTokenRefresher.swift */; };
+		49C1B1A2000000000001AABB /* GrokQuotaClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C1B1A2000000000001AAAA /* GrokQuotaClient.swift */; };
+		49C1B1A3000000000001AABB /* grok.svg in Resources */ = {isa = PBXBuildFile; fileRef = 49C1B1A3000000000001AAAA /* grok.svg */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -150,6 +154,10 @@
 		49C1B301000000000001AAAA /* CCBarTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CCBarTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		49C1B3F0000000000001AAAA /* codex-fast-scan.jsonl */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "codex-fast-scan.jsonl"; sourceTree = "<group>"; };
 		49C1B3F1000000000001AAAA /* claude-fast-scan.jsonl */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "claude-fast-scan.jsonl"; sourceTree = "<group>"; };
+49C1B1A0000000000001AAAA /* GrokAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrokAuth.swift; sourceTree = "<group>"; };
+		49C1B1A1000000000001AAAA /* GrokTokenRefresher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrokTokenRefresher.swift; sourceTree = "<group>"; };
+		49C1B1A2000000000001AAAA /* GrokQuotaClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrokQuotaClient.swift; sourceTree = "<group>"; };
+		49C1B1A3000000000001AAAA /* grok.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = grok.svg; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -256,6 +264,7 @@
 				49C1B102000000000001AAAA /* JWT.swift */,
 				49C1B103000000000001AAAA /* CodexAuth.swift */,
 				49C1B104000000000001AAAA /* ClaudeAuth.swift */,
+				49C1B1A0000000000001AAAA /* GrokAuth.swift */,
 				49C1B191000000000001AAAA /* ImportedCodexAccount.swift */,
 				49C1B192000000000001AAAA /* ImportedCodexStore.swift */,
 			);
@@ -283,6 +292,8 @@
 				49C1B122000000000001AAAA /* CodexQuotaClient.swift */,
 				49C1B128000000000001AAAA /* CodexResetCreditsClient.swift */,
 				49C1B129000000000001AAAA /* AntigravityQuotaClient.swift */,
+				49C1B1A1000000000001AAAA /* GrokTokenRefresher.swift */,
+				49C1B1A2000000000001AAAA /* GrokQuotaClient.swift */,
 				49C1B123000000000001AAAA /* ClaudeQuotaClient.swift */,
 				49C1B124000000000001AAAA /* ClaudeCLIFallbackQuotaClient.swift */,
 				49C1B125000000000001AAAA /* ClaudeTokenRefresher.swift */,
@@ -298,6 +309,7 @@
 				49C1B140000000000001AAAA /* codex.svg */,
 				49C1B141000000000001AAAA /* claude.svg */,
 				49C1B143000000000001AAAA /* antigravity.svg */,
+				49C1B1A3000000000001AAAA /* grok.svg */,
 			);
 			path = Logos;
 			sourceTree = "<group>";
@@ -490,6 +502,7 @@
 				49C1B140000000000001AABB /* codex.svg in Resources */,
 				49C1B141000000000001AABB /* claude.svg in Resources */,
 				49C1B143000000000001AABB /* antigravity.svg in Resources */,
+				49C1B1A3000000000001AABB /* grok.svg in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -542,6 +555,7 @@
 				49C1B102000000000001AABB /* JWT.swift in Sources */,
 				49C1B103000000000001AABB /* CodexAuth.swift in Sources */,
 				49C1B104000000000001AABB /* ClaudeAuth.swift in Sources */,
+				49C1B1A0000000000001AABB /* GrokAuth.swift in Sources */,
 				49C1B105000000000001AABB /* Settings.swift in Sources */,
 				49C1B106000000000001AABB /* QuotaCache.swift in Sources */,
 				49C1B120000000000001AABB /* QuotaModels.swift in Sources */,
@@ -549,6 +563,8 @@
 				49C1B122000000000001AABB /* CodexQuotaClient.swift in Sources */,
 				49C1B128000000000001AABB /* CodexResetCreditsClient.swift in Sources */,
 				49C1B129000000000001AABB /* AntigravityQuotaClient.swift in Sources */,
+				49C1B1A1000000000001AABB /* GrokTokenRefresher.swift in Sources */,
+				49C1B1A2000000000001AABB /* GrokQuotaClient.swift in Sources */,
 				49C1B123000000000001AABB /* ClaudeQuotaClient.swift in Sources */,
 				49C1B124000000000001AABB /* ClaudeCLIFallbackQuotaClient.swift in Sources */,
 				49C1B125000000000001AABB /* ClaudeTokenRefresher.swift in Sources */,


### PR DESCRIPTION
## 摘要
增加 Grok Build（xAI）作为第四个 Provider。

## 改动
- 凭据：`~/.grok/auth.json` + OIDC 续期
- 额度：`cli-chat-proxy` billing credits + 订阅档位
- 用量：扫 `~/.grok/sessions/**/updates.jsonl`，费用优先 `costUsdTicks`
- UI：菜单栏 / 设置 / 统计 / 时间线

Closes 3

## 测试
- 本地 macOS Debug 构建通过
- Grok 解析 / 计价单测通过